### PR TITLE
Preparation for 64-bit TeamViewer on Windows

### DIFF
--- a/TeamViewerPS/Private/Get-TeamViewerRegKeyPath.ps1
+++ b/TeamViewerPS/Private/Get-TeamViewerRegKeyPath.ps1
@@ -1,5 +1,11 @@
 function Get-TeamViewerRegKeyPath {
-    if ([Environment]::Is64BitOperatingSystem) {
+    param (
+        [Parameter()]
+        [ValidateSet('WOW6432', 'Auto')]
+        [string]
+        $Variant = 'Auto'
+    )
+    if (($Variant -eq 'WOW6432') -Or (Test-TeamViewer32on64)) {
         Write-Output 'HKLM:\SOFTWARE\Wow6432Node\TeamViewer'
     }
     else {

--- a/TeamViewerPS/Private/Test-TeamViewer32on64.ps1
+++ b/TeamViewerPS/Private/Test-TeamViewer32on64.ps1
@@ -1,0 +1,17 @@
+function Test-TeamViewer32on64 {
+    if (![Environment]::Is64BitOperatingSystem) {
+        return $false
+    }
+    $registryKey = Get-TeamViewerRegKeyPath -Variant WOW6432
+    if (!(Test-Path $registryKey)) {
+        return $false
+    }
+    try {
+        $installationDirectory = (Get-Item $registryKey).GetValue('InstallationDirectory')
+        $binaryPath = Join-Path $installationDirectory 'TeamViewer.exe'
+        return Test-Path $binaryPath
+    }
+    catch {
+        return $false
+    }
+}

--- a/TeamViewerPS/Public/Invoke-TeamViewerPackageDownload.ps1
+++ b/TeamViewerPS/Public/Invoke-TeamViewerPackageDownload.ps1
@@ -1,7 +1,7 @@
 function Invoke-TeamViewerPackageDownload {
     Param(
         [Parameter()]
-        [ValidateSet('Full', 'Host', 'Portable', 'QuickJoin', 'QuickSupport')]
+        [ValidateSet('Full', 'Host', 'Portable', 'QuickJoin', 'QuickSupport', 'Full64Bit')]
         [ValidateScript( {
                 if (($_ -ne 'Full') -And ((Get-OperatingSystem) -ne 'Windows')) {
                     $PSCmdlet.ThrowTerminatingError(
@@ -48,6 +48,7 @@ function Invoke-TeamViewerPackageDownload {
                 'Portable' { 'TeamViewerPortable.zip' }
                 'QuickJoin' { 'TeamViewerQJ.exe' }
                 'QuickSupport' { 'TeamViewerQS.exe' }
+                'Full64Bit' { 'TeamViewer_Setup_x64.exe' }
             }
             if ($MajorVersion) {
                 $additionalPath = "/version_$($MajorVersion)x"

--- a/TeamViewerPS/Public/Test-TeamViewerInstallation.ps1
+++ b/TeamViewerPS/Public/Test-TeamViewerInstallation.ps1
@@ -1,9 +1,11 @@
 function Test-TeamViewerInstallation {
     switch (Get-OperatingSystem) {
         'Windows' {
+            $regKey = Get-TeamViewerRegKeyPath
+            $installationDirectory = if (Test-Path $regKey) { (Get-Item $regKey).GetValue('InstallationDirectory') }
             Write-Output (
-                (Test-Path (Get-TeamViewerRegKeyPath)) -And `
-                (Test-Path "$(Get-ItemPropertyValue -Path (Get-TeamViewerRegKeyPath) -Name 'InstallationDirectory')/TeamViewer.exe")
+                $installationDirectory -And `
+                (Test-Path "$installationDirectory/TeamViewer.exe")
             )
         }
         'Linux' {

--- a/Tests/Public/Test-TeamViewerInstallation.Tests.ps1
+++ b/Tests/Public/Test-TeamViewerInstallation.Tests.ps1
@@ -9,9 +9,16 @@ BeforeAll {
 Describe 'Test-TeamViewerInstallation' {
     Context 'Windows' {
         BeforeAll {
+            function Get-TestItemValue([object]$obj) {}
+            Mock Get-TestItemValue { 'testPath' }
+            $testItem = [PSCustomObject]@{}
+            $testItem | Add-Member `
+                -MemberType ScriptMethod `
+                -Name GetValue `
+                -Value { param($obj) Get-TestItemValue @PSBoundParameters }
             Mock Get-OperatingSystem { 'Windows' }
             Mock Get-TeamViewerRegKeyPath { 'testRegistry' }
-            Mock Get-ItemPropertyValue { 'testPath' }
+            Mock Get-Item { $testItem }
             Mock Test-Path { $true }
         }
 
@@ -23,8 +30,11 @@ Describe 'Test-TeamViewerInstallation' {
             Assert-MockCalled Test-Path -Scope It -Times 1 -ParameterFilter {
                 $Path -eq 'testPath/TeamViewer.exe'
             }
-            Assert-MockCalled Get-ItemPropertyValue -Scope It -Times 1 -ParameterFilter {
-                $Path -eq 'testRegistry' -And $Name -eq 'InstallationDirectory'
+            Assert-MockCalled Get-Item -Scope It -Times 1 -ParameterFilter {
+                $Path -eq 'testRegistry'
+            }
+            Assert-MockCalled Get-TestItemValue -Scope It -Times 1 -ParameterFilter {
+                $obj -eq 'InstallationDirectory'
             }
         }
 

--- a/docs/commands/Invoke-TeamViewerPackageDownload.md
+++ b/docs/commands/Invoke-TeamViewerPackageDownload.md
@@ -81,7 +81,7 @@ available on Windows platforms.
 Type: String
 Parameter Sets: (All)
 Aliases:
-Accepted values: Full, Host, Portable, QuickJoin, QuickSupport
+Accepted values: Full, Host, Portable, QuickJoin, QuickSupport, Full64Bit
 
 Required: False
 Position: 0


### PR DESCRIPTION
This prepares the module to distinguish between 32-bit and 64-bit Windows TeamViewer installations.
Also fixes a small issue in `Test-TeamViewerInstallation`.