### PR TITLE
Adds Get-TeamViewerManagementId command

### DIFF
--- a/TeamViewerPS/Private/Get-TeamViewerLinuxGlobalConfig.ps1
+++ b/TeamViewerPS/Private/Get-TeamViewerLinuxGlobalConfig.ps1
@@ -9,7 +9,7 @@ function Get-TeamViewerLinuxGlobalConfig {
         $Name
     )
     $config = Get-Content $Path | ForEach-Object {
-        if ($_ -Match '\[(?<EntryType>\w+)\]\s+(?<EntryName>\w+)\s+=\s*(?<EntryValue>.*)$') {
+        if ($_ -Match '\[(?<EntryType>\w+)\s*\]\s+(?<EntryName>[\w\\]+)\s+=\s*(?<EntryValue>.*)$') {
             $Matches.Remove(0)
             $entry = [pscustomobject]$Matches
             switch ($entry.EntryType) {
@@ -18,6 +18,12 @@ function Get-TeamViewerLinuxGlobalConfig {
                         Select-String -Pattern '"([^\"]*)"' -AllMatches | `
                         Select-Object -ExpandProperty Matches | `
                         ForEach-Object { $_.Groups[1].Value }
+                }
+                'int32' {
+                    $entry.EntryValue = [int32]($entry.EntryValue)
+                }
+                'int64' {
+                    $entry.EntryValue = [int64]($entry.EntryValue)
                 }
             }
             $entry

--- a/TeamViewerPS/Public/Get-TeamViewerManagementId.ps1
+++ b/TeamViewerPS/Public/Get-TeamViewerManagementId.ps1
@@ -1,0 +1,21 @@
+function Get-TeamViewerManagementId {
+    if (Test-TeamViewerInstallation) {
+        switch (Get-OperatingSystem) {
+            'Windows' {
+                $regKeyPath = Join-Path (Get-TeamViewerRegKeyPath) 'DeviceManagementV2'
+                $regKey = if (Test-Path -LiteralPath $regKeyPath) { Get-Item -Path $regKeyPath }
+                if ($regKey) {
+                    $unmanaged = [bool]($regKey.GetValue('Unmanaged'))
+                    $managementId = $regKey.GetValue('ManagementId')
+                }
+            }
+            'Linux' {
+                $unmanaged = [bool](Get-TeamViewerLinuxGlobalConfig -Name 'DeviceManagementV2\Unmanaged')
+                $managementId = Get-TeamViewerLinuxGlobalConfig -Name 'DeviceManagementV2\ManagementId'
+            }
+        }
+        if (!$unmanaged -And $managementId) {
+            Write-Output ([guid]$managementId)
+        }
+    }
+}

--- a/Tests/Public/Get-TeamViewerManagementId.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerManagementId.Tests.ps1
@@ -1,0 +1,101 @@
+BeforeAll {
+    . "$PSScriptRoot/../../TeamViewerPS/Public/Get-TeamViewerManagementId.ps1"
+
+    . "$PSScriptRoot/../../TeamViewerPS/Public/Test-TeamViewerInstallation.ps1"
+    @(Get-ChildItem -Path "$PSScriptRoot/../../TeamViewerPS/Private/*.ps1") | `
+        ForEach-Object { . $_.FullName }
+    $testManagementId = New-Guid
+    $null = $testManagementId
+}
+
+Describe 'Get-TeamViewerManagementId' {
+    Context 'Windows' {
+        BeforeAll {
+            function Get-TestItemValue([object]$obj) {}
+            Mock Get-TestItemValue `
+                -ParameterFilter { $obj -eq 'Unmanaged' } { }
+            Mock Get-TestItemValue `
+                -ParameterFilter { $obj -eq 'ManagementId' } { $testManagementId.ToString("B") }
+            $testItem = [PSCustomObject]@{}
+            $testItem | Add-Member `
+                -MemberType ScriptMethod `
+                -Name GetValue `
+                -Value { param($obj) Get-TestItemValue @PSBoundParameters }
+            Mock Get-OperatingSystem { 'Windows' }
+            Mock Get-TeamViewerRegKeyPath { 'testRegistry' }
+            Mock Get-Item { $testItem }
+            Mock Test-Path { $true }
+            Mock Test-TeamViewerInstallation { $true }
+        }
+
+        It 'Should return the Management ID from the Windows Registry' {
+            Get-TeamViewerManagementId | Should -Be $testManagementId
+            Assert-MockCalled Test-TeamViewerInstallation -Scope It -Times 1
+            Assert-MockCalled Get-OperatingSystem -Scope It -Times 1
+            Assert-MockCalled Get-TeamViewerRegKeyPath -Scope It -Times 1
+            Assert-MockCalled Test-Path -Scope It -Times 1 -ParameterFilter {
+                $LiteralPath -eq (Join-Path 'testRegistry' 'DeviceManagementV2')
+            }
+            Assert-MockCalled Get-Item -Scope It -Times 1 -ParameterFilter {
+                $Path -eq (Join-Path 'testRegistry' 'DeviceManagementV2')
+            }
+            Assert-MockCalled Get-TestItemValue -Scope It -Times 1 -ParameterFilter {
+                $obj -eq 'Unmanaged'
+            }
+            Assert-MockCalled Get-TestItemValue -Scope It -Times 1 -ParameterFilter {
+                $obj -eq 'ManagementId'
+            }
+        }
+
+        It 'Should return nothing when TeamViewer is not installed' {
+            Mock Test-TeamViewerInstallation { $false }
+            Get-TeamViewerManagementId | Should -BeNullOrEmpty
+        }
+
+        It 'Should return nothing when registry path does not exist' {
+            Mock Test-Path { $false }
+            Get-TeamViewerManagementId | Should -BeNullOrEmpty
+        }
+
+        It 'Should return nothing when registry item does not exist' {
+            Mock Get-Item { }
+            Get-TeamViewerManagementId | Should -BeNullOrEmpty
+        }
+
+        It 'Should return nothing when the device is marked as unmanaged' {
+            Mock Get-TestItemValue -ParameterFilter { $obj -eq 'Unmanaged' } { 1 }
+            Get-TeamViewerManagementId | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'Linux' {
+        BeforeAll {
+            Mock Get-OperatingSystem { 'Linux' }
+            Mock Test-TeamViewerInstallation { $true }
+            Mock Get-TeamViewerLinuxGlobalConfig `
+                -ParameterFilter { $Name -eq 'DeviceManagementV2\Unmanaged' } `
+                -MockWith { }
+            Mock Get-TeamViewerLinuxGlobalConfig `
+                -ParameterFilter { $Name -eq 'DeviceManagementV2\ManagementId' } `
+                -MockWith { $testManagementId.ToString("B") }
+        }
+
+        It 'Should return the Management ID from the global configuration' {
+            Get-TeamViewerManagementId | Should -Be $testManagementId
+            Assert-MockCalled Test-TeamViewerInstallation -Scope It -Times 1
+            Assert-MockCalled Get-OperatingSystem -Scope It -Times 1
+        }
+
+        It 'Should return nothing when TeamViewer is not installed' {
+            Mock Test-TeamViewerInstallation { $false }
+            Get-TeamViewerManagementId | Should -BeNullOrEmpty
+        }
+
+        It 'Should return nothing when the device is marked as unmanaged' {
+            Mock Get-TeamViewerLinuxGlobalConfig `
+                -ParameterFilter { $Name -eq 'DeviceManagementV2\Unmanaged' } `
+                -MockWith { 1 }
+            Get-TeamViewerManagementId | Should -BeNullOrEmpty
+        }
+    }
+}

--- a/docs/commands/Get-TeamViewerManagementId.md
+++ b/docs/commands/Get-TeamViewerManagementId.md
@@ -1,0 +1,52 @@
+---
+external help file: TeamViewerPS-help.xml
+Module Name: TeamViewerPS
+online version: https://github.com/teamviewer/TeamViewerPS/blob/main/docs/commands/Get-TeamViewerManagementId.md
+schema: 2.0.0
+---
+
+# Get-TeamViewerManagementId
+
+## SYNOPSIS
+
+Returns the TeamViewer Management ID of the locally installed TeamViewer.
+
+## SYNTAX
+
+```powershell
+Get-TeamViewerManagementId
+```
+
+## DESCRIPTION
+
+Returns the TeamViewer Management ID of the locally installed TeamViewer if the
+device is managed in the Managed Groups system.
+Returns nothing if either TeamViewer is not installed or the device is not a
+managed device in the Managed Groups system.
+For example, the management ID can be used as `DeviceId` for the
+`Get-TeamViewerManagedDevice` command (and all other Managed Device/Group
+related commands). 
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+PS /> Get-TeamViewerManagementId
+```
+
+## PARAMETERS
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+The command returns the Management ID as GUID object.
+
+## NOTES
+
+## RELATED LINKS
+
+[Get-TeamViewerManagedDevice](Get-TeamViewerManagedGroup.md)


### PR DESCRIPTION
The command fetches the management ID of the current device from the registry/config.