### PR TITLE
Adds Set-TeamViewerManagedDevice command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,12 @@ jobs:
           Install-Module PSScriptAnalyzer -Force -SkipPublisherCheck -Scope CurrentUser `
             -RequiredVersion 1.19.1 -Verbose
           Invoke-ScriptAnalyzer -Path $env:GITHUB_WORKSPACE -Recurse -ReportSummary -EnableExit
+
+      # Try to build the package
+      - name: Package Build
+        shell: pwsh
+        run: |
+          $ProgressPreference='SilentlyContinue'
+          $ErrorActionPreference='Stop'
+          Install-Module platyPS,BuildHelpers -Force -SkipPublisherCheck -Scope CurrentUser
+          & $env:GITHUB_WORKSPACE/Build/New-TeamViewerPSPackage.ps1 -Verbose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Adds command `Set-TeamViewerManagedDevice` to change properties of a managed device.
 - Adds optional `Policy` property to `Get-TeamViewerManagedDevice` result entries.
+- Adds `-Device` parameter to `Get-TeamViewerManagedGroup` command, allowing to
+  fetch all managed groups that a particular device is part of.
 
 ## 1.1.0 (2021-04-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## 1.2.0
+
+### Added
+
+- Adds command `Set-TeamViewerManagedDevice` to change properties of a managed device.
+- Adds optional `Policy` property to `Get-TeamViewerManagedDevice` result entries.
+
 ## 1.1.0 (2021-04-15)
 
 ### Added

--- a/TeamViewerPS/Private/ConvertTo-TeamViewerManagedDevice.ps1
+++ b/TeamViewerPS/Private/ConvertTo-TeamViewerManagedDevice.ps1
@@ -16,6 +16,10 @@ function ConvertTo-TeamViewerManagedDevice {
             $properties["PendingOperation"] = $InputObject.pendingOperation
         }
 
+        if ($InputObject.teamviewerPolicyId) {
+            $properties["PolicyId"] = [guid]$InputObject.teamviewerPolicyId
+        }
+
         $result = New-Object -TypeName PSObject -Property $properties
         $result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.ManagedDevice')
         Write-Output $result

--- a/TeamViewerPS/Public/Get-TeamViewerManagedDevice.ps1
+++ b/TeamViewerPS/Public/Get-TeamViewerManagedDevice.ps1
@@ -8,6 +8,7 @@ function Get-TeamViewerManagedDevice {
         [Parameter(ParameterSetName = "ByDeviceId")]
         [ValidateScript( { $_ | Resolve-TeamViewerManagedDeviceId } )]
         [Alias("DeviceId")]
+        [Alias("Device")]
         [guid]
         $Id,
 

--- a/TeamViewerPS/Public/Get-TeamViewerManagedGroup.ps1
+++ b/TeamViewerPS/Public/Get-TeamViewerManagedGroup.ps1
@@ -9,16 +9,26 @@ function Get-TeamViewerManagedGroup {
         [ValidateScript( { $_ | Resolve-TeamViewerManagedGroupId } ) ]
         [Alias("GroupId")]
         [guid]
-        $Id
+        $Id,
+
+        [Parameter(ParameterSetName = "ByDeviceId")]
+        [ValidateScript( { $_ | Resolve-TeamViewerManagedDeviceId } )]
+        [Alias("DeviceId")]
+        [object]
+        $Device
     )
 
-    $resourceUri = "$(Get-TeamViewerApiUri)/managed/groups";
+    $resourceUri = "$(Get-TeamViewerApiUri)/managed/groups"
     $parameters = @{ }
 
     switch ($PsCmdlet.ParameterSetName) {
         'ByGroupId' {
             $resourceUri += "/$Id"
             $parameters = $null
+        }
+        'ByDeviceId' {
+            $deviceId = $Device | Resolve-TeamViewerManagedDeviceId
+            $resourceUri = "$(Get-TeamViewerApiUri)/managed/devices/$deviceId/groups"
         }
     }
 
@@ -38,5 +48,6 @@ function Get-TeamViewerManagedGroup {
             $parameters.paginationToken = $response.nextPaginationToken
             Write-Output ($response.resources | ConvertTo-TeamViewerManagedGroup)
         }
-    } while ($PsCmdlet.ParameterSetName -Eq 'List' -And $parameters.paginationToken)
+    } while ($PsCmdlet.ParameterSetName -In @('List', 'ByDeviceId') `
+            -And $parameters.paginationToken)
 }

--- a/TeamViewerPS/Public/Set-TeamViewerManagedDevice.ps1
+++ b/TeamViewerPS/Public/Set-TeamViewerManagedDevice.ps1
@@ -1,0 +1,67 @@
+function Set-TeamViewerManagedDevice {
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param(
+        [Parameter(Mandatory = $true)]
+        [securestring]
+        $ApiToken,
+
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [ValidateScript( { $_ | Resolve-TeamViewerManagedDeviceId } )]
+        [Alias("DeviceId")]
+        [object]
+        $Device,
+
+        [Alias("Alias")]
+        [string]
+        $Name,
+
+        [ValidateScript( { $_ | Resolve-TeamViewerPolicyId } )]
+        [Alias("PolicyId")]
+        [object]
+        $Policy,
+
+        [switch]
+        $RemovePolicy
+    )
+    Begin {
+        $body = @{}
+
+        if ($Name) {
+            $body['name'] = $Name
+        }
+        if ($Policy) {
+            $body['teamviewerPolicyId'] = $Policy | Resolve-TeamViewerPolicyId
+        }
+        elseif ($RemovePolicy) {
+            $body['teamviewerPolicyId'] = ""
+        }
+
+        if ($Policy -And $RemovePolicy) {
+            $PSCmdlet.ThrowTerminatingError(
+                ("Parameters -Policy and -RemovePolicy cannot be used together." | `
+                        ConvertTo-ErrorRecord -ErrorCategory InvalidArgument))
+        }
+
+        if ($body.Count -eq 0) {
+            $PSCmdlet.ThrowTerminatingError(
+                ("The given input does not change the managed device." | `
+                        ConvertTo-ErrorRecord -ErrorCategory InvalidArgument))
+        }
+    }
+    Process {
+        $deviceId = $Device | Resolve-TeamViewerManagedDeviceId
+        $resourceUri = "$(Get-TeamViewerApiUri)/managed/devices/$deviceId"
+
+        if ($PSCmdlet.ShouldProcess($Device.ToString(), "Change managed device entry")) {
+            Invoke-TeamViewerRestMethod `
+                -ApiToken $ApiToken `
+                -Uri $resourceUri `
+                -Method Put `
+                -ContentType "application/json; charset=utf-8" `
+                -Body ([System.Text.Encoding]::UTF8.GetBytes(($body | ConvertTo-Json))) `
+                -WriteErrorTo $PSCmdlet `
+                -ErrorAction Stop | `
+                Out-Null
+        }
+    }
+}

--- a/Tests/Public/Set-TeamViewerManagedDevice.Tests.ps1
+++ b/Tests/Public/Set-TeamViewerManagedDevice.Tests.ps1
@@ -1,0 +1,81 @@
+BeforeAll {
+    . "$PSScriptRoot/../../TeamViewerPS/Public/Set-TeamViewerManagedDevice.ps1"
+
+    @(Get-ChildItem -Path "$PSScriptRoot/../../TeamViewerPS/Private/*.ps1") | `
+        ForEach-Object { . $_.FullName }
+
+    $testApiToken = [securestring]@{}
+    $null = $testApiToken
+    $testDeviceId = '9e5617cb-2b20-4da2-bca4-c1bda85b29ab'
+    $null = $testDeviceId
+
+    Mock Get-TeamViewerApiUri { '//unit.test' }
+    $mockArgs = @{}
+    Mock Invoke-TeamViewerRestMethod { $mockArgs.Body = $Body }
+}
+
+Describe 'Set-TeamViewerManagedDevice' {
+
+    It 'Should call the correct API endpoint to update a managed device' {
+        Set-TeamViewerManagedDevice -ApiToken $testApiToken -Device $testDeviceId -Name 'Foo Bar'
+        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+            $ApiToken -eq $testApiToken -And `
+                $Uri -eq "//unit.test/managed/devices/$testDeviceId" -And `
+                $Method -eq 'Put' }
+    }
+
+    It 'Should update the managed device alias' {
+        Set-TeamViewerManagedDevice -ApiToken $testApiToken -Device $testDeviceId -Name 'Foo Bar'
+        $mockArgs.Body | Should -Not -BeNullOrEmpty
+        $body = [System.Text.Encoding]::UTF8.GetString($mockArgs.Body) | ConvertFrom-Json
+        $body.name | Should -Be 'Foo Bar'
+    }
+
+    It 'Should update the managed device policy' {
+        Set-TeamViewerManagedDevice -ApiToken $testApiToken -Device $testDeviceId -Policy '2871c013-3040-4969-9ba4-ce970f4375e8'
+        $mockArgs.Body | Should -Not -BeNullOrEmpty
+        $body = [System.Text.Encoding]::UTF8.GetString($mockArgs.Body) | ConvertFrom-Json
+        $body.teamviewerPolicyId | Should -Be '2871c013-3040-4969-9ba4-ce970f4375e8'
+    }
+
+    It 'Should remove the managed device policy' {
+        Set-TeamViewerManagedDevice -ApiToken $testApiToken -Device $testDeviceId -RemovePolicy
+        $mockArgs.Body | Should -Not -BeNullOrEmpty
+        $body = [System.Text.Encoding]::UTF8.GetString($mockArgs.Body) | ConvertFrom-Json
+        $body.teamviewerPolicyId | Should -Be ''
+    }
+
+    It 'Should not be possible to set and remove the policy at the same time' {
+        { Set-TeamViewerManagedDevice `
+                -ApiToken $testApiToken `
+                -Device $testDeviceId `
+                -Policy '2871c013-3040-4969-9ba4-ce970f4375e8' `
+                -RemovePolicy } | Should -Throw
+    }
+
+    It 'Should not be possible to use "none" or "inherit" as values for policy' {
+        { Set-TeamViewerManagedDevice `
+                -ApiToken $testApiToken `
+                -Device $testDeviceId `
+                -Policy 'none' } | Should -Throw
+        { Set-TeamViewerManagedDevice `
+                -ApiToken $testApiToken `
+                -Device $testDeviceId `
+                -Policy 'inherit' } | Should -Throw
+    }
+
+    It 'Should accept a ManagedDevice object as input' {
+        $testDevice = @{ id = $testDeviceId; name = 'test device' } | ConvertTo-TeamViewerManagedDevice
+        Set-TeamViewerManagedDevice -ApiToken $testApiToken -Device $testDevice -Name 'Foo Bar'
+        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+            $ApiToken -eq $testApiToken -And `
+                $Uri -eq "//unit.test/managed/devices/$testDeviceId" -And `
+                $Method -eq 'Put' }
+    }
+
+    It 'Should throw an error when called without changes' {
+        { Set-TeamViewerManagedDevice `
+                -ApiToken $testApiToken `
+                -Device $testDeviceId } | Should -Throw
+    }
+}

--- a/docs/about_TeamViewerPS.md
+++ b/docs/about_TeamViewerPS.md
@@ -78,6 +78,8 @@ The following functions are available in this category:
 
 [`New-TeamViewerManagedGroup`](commands/New-TeamViewerManagedGroup.md)
 
+[`Set-TeamViewerManagedDevice](commands/Set-TeamViewerManagedDevice.md)
+
 [`Set-TeamViewerManagedGroup`](commands/Set-TeamViewerManagedGroup.md)
 
 [`Set-TeamViewerManager`](commands/Set-TeamViewerManager.md)

--- a/docs/commands/Get-TeamViewerManagedGroup.md
+++ b/docs/commands/Get-TeamViewerManagedGroup.md
@@ -25,6 +25,12 @@ Get-TeamViewerManagedGroup -ApiToken <SecureString> [<CommonParameters>]
 Get-TeamViewerManagedGroup -ApiToken <SecureString> [-Id <Guid>] [<CommonParameters>]
 ```
 
+### ByDeviceId
+
+```powershell
+Get-TeamViewerManagedGroup -ApiToken <SecureString> [-Device <Object>] [<CommonParameters>]
+```
+
 ## DESCRIPTION
 
 Retrieves managed groups of the manager that is associated with the API access
@@ -60,6 +66,27 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Device
+
+Object that can be used to identify a managed device.
+This can either be the managed device ID (as string or GUID) or a managed device
+object that has been received using other module functions.
+
+If given, this command returns the list of managed groups that the device is
+part of.
+
+```yaml
+Type: Object
+Parameter Sets: ByDeviceId
+Aliases: DeviceId
+
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/docs/commands/Set-TeamViewerManagedDevice.md
+++ b/docs/commands/Set-TeamViewerManagedDevice.md
@@ -1,0 +1,193 @@
+---
+external help file: TeamViewerPS-help.xml
+Module Name: TeamViewerPS
+online version: https://github.com/teamviewer/TeamViewerPS/blob/main/docs/commands/Set-TeamViewerManagedDevice.md
+schema: 2.0.0
+---
+
+# Set-TeamViewerManagedDevice
+
+## SYNOPSIS
+
+Change properties of a TeamViewer managed device.
+
+## SYNTAX
+
+```powershell
+Set-TeamViewerManagedDevice [-ApiToken] <SecureString> [-Device] <Object> [[-Name] <String>]
+ [[-Policy] <Object>] [-RemovePolicy] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+Changes properties of a managed device. For example, the name of the managed
+device or the policy can be changed.
+
+For changing the device name, the current account needs `DeviceAdministration`
+manager permissions on the device.
+
+For changing the device's policy, the current account needs
+`PolicyAdministration` manager permissions on the device.
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+PS /> Set-TeamViewerManagedDevice -Device '33a2e2e1-27ef-43e2-a175-f97ee0344033' -Name 'My Device'
+```
+
+Changes the device alias.
+
+### Example 2
+
+```powershell
+PS /> Set-TeamViewerManagedDevice -Device '33a2e2e1-27ef-43e2-a175-f97ee0344033' -Policy '63351a3e-3077-41ae-9f66-b38a61965485'
+```
+
+Sets the policy of the device.
+
+### Example 3
+
+```powershell
+PS /> Set-TeamViewerManagedDevice -Device '33a2e2e1-27ef-43e2-a175-f97ee0344033' -RemovePolicy
+```
+
+Removes the policy from the managed device.
+
+## PARAMETERS
+
+### -ApiToken
+
+The TeamViewer API access token.
+
+```yaml
+Type: SecureString
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Device
+
+Object that can be used to identify the managed device.
+This can either be the managed device ID (as string or GUID) or a managed device
+object that has been received using other module functions.
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases: DeviceId
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Name
+
+New alias for the managed device.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: Alias
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Policy
+
+Object that can be used to identify the policy.
+This can either be the policy ID (as string or GUID) or a policy object that has
+been received using other module functions.
+
+Cannot be used in conjunction with the `-RemovePolicy` parameter.
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases: PolicyId
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RemovePolicy
+
+Removes the policy from the managed device.
+
+Cannot be used in conjunction with the `-Policy` parameter.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.Object
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS


### PR DESCRIPTION
The command can be used to change properties of a managed device:

- Change the managed device alias (name)
- Change/Remove the policy on the managed device