### PR TITLE
Fixes Set-TeamViewerPolicy payload to be able to contain policy settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Change Log
 
+## 1.3.1 (2021-11)
+
+### Fixed
+
+- Fixed `Set-TeamViewerPolicy` to support changing policy settings.
+
 ## 1.3.0 (2021-11-29)
+
+### Added
 
 - Adds command `Get-TeamViewerEventLog` to fetch event log entries.
 - Adds user group commands to remotely manage user groups of a TeamViewer company.

--- a/TeamViewerPS/Public/Set-TeamViewerPolicy.ps1
+++ b/TeamViewerPS/Public/Set-TeamViewerPolicy.ps1
@@ -59,7 +59,7 @@ function Set-TeamViewerPolicy {
             -Uri $resourceUri `
             -Method Put `
             -ContentType "application/json; charset=utf-8" `
-            -Body ([System.Text.Encoding]::UTF8.GetBytes(($body | ConvertTo-Json))) `
+            -Body ([System.Text.Encoding]::UTF8.GetBytes(($body | ConvertTo-Json -Depth 25))) `
             -WriteErrorTo $PSCmdlet | `
             Out-Null
     }

--- a/TeamViewerPS/TeamViewerPS.psd1
+++ b/TeamViewerPS/TeamViewerPS.psd1
@@ -3,7 +3,7 @@
     RootModule        = 'TeamViewerPS.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '1.3.0'
+    ModuleVersion     = '1.3.1'
 
     # Supported PSEditions.
     # CompatiblePSEditions = @()

--- a/Tests/Public/Set-TeamViewerPolicy.Tests.ps1
+++ b/Tests/Public/Set-TeamViewerPolicy.Tests.ps1
@@ -38,6 +38,29 @@ Describe 'Set-TeamViewerPolicy' {
         $body.name | Should -Be 'Updated Policy Name'
     }
 
+    It 'Should change policy settings' {
+        $settings = @{
+            Key     = "BlackWhitelist"
+            Value   = @{
+                UseWhiteList             = $true
+                WhiteListBuddyAccountIds = @(123, 456, 789)
+            }
+            Enforce = $true
+        }
+        Set-TeamViewerPolicy `
+            -ApiToken $testApiToken `
+            -PolicyId $testPolicyId `
+            -Settings $settings
+
+        $mockArgs.Body | Should -Not -BeNullOrEmpty
+        $body = [System.Text.Encoding]::UTF8.GetString($mockArgs.Body) | ConvertFrom-Json
+        $body.settings | Should -HaveCount 1
+        $body.settings[0].Key | Should -Be 'BlackWhitelist'
+        $body.settings[0].Value.UseWhiteList | Should -BeTrue
+        $body.settings[0].Value.WhiteListBuddyAccountIds | Should -HaveCount 3
+        $body.settings[0].Value.WhiteListBuddyAccountIds | Should -Be @(123,456,789)
+    }
+
     It 'Should accept policy properties as hashtable' {
         Set-TeamViewerPolicy `
             -ApiToken $testApiToken `


### PR DESCRIPTION
The policy settings are nested as JSON objects. Therefore the JSON conversion
must support nested objects deeper than the default 2.