### PR TITLE
Add policy management capabilities for managed devices

### DIFF
--- a/TeamViewerPS/Public/Remove-TeamViewerPolicyFromManagedDevice.ps1
+++ b/TeamViewerPS/Public/Remove-TeamViewerPolicyFromManagedDevice.ps1
@@ -1,0 +1,39 @@
+function Remove-TeamviewerPolicyFromManagedDevice {
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param(
+        [Parameter(Mandatory = $true)]
+        [securestring]
+        $ApiToken,
+
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [ValidateScript( { $_ | Resolve-TeamViewerManagedDeviceId } )]
+        [Alias("DeviceId")]
+        [object]
+        $Device,
+
+        [Parameter(Mandatory = $true)]
+        [PolicyType]
+        $PolicyType
+    )
+    Begin {
+        $body = @{
+            'policy_type' = [int]$PolicyType
+        }
+    }
+    Process {
+        $deviceId = $Device | Resolve-TeamViewerManagedDeviceId
+        $resourceUri = "$(Get-TeamViewerApiUri)/managed/devices/$deviceId/policy/remove"
+
+        if ($PSCmdlet.ShouldProcess($Device.ToString(), "Change managed device entry")) {
+            Invoke-TeamViewerRestMethod `
+                -ApiToken $ApiToken `
+                -Uri $resourceUri `
+                -Method Put `
+                -ContentType "application/json; charset=utf-8" `
+                -Body ([System.Text.Encoding]::UTF8.GetBytes(($body | ConvertTo-Json))) `
+                -WriteErrorTo $PSCmdlet `
+                -ErrorAction Stop | `
+                Out-Null
+        }
+    }
+}

--- a/TeamViewerPS/Public/Set-TeamViewerManagedDevice.ps1
+++ b/TeamViewerPS/Public/Set-TeamViewerManagedDevice.ps1
@@ -20,6 +20,11 @@ function Set-TeamViewerManagedDevice {
         [object]
         $Policy,
 
+        [ValidateScript( { $_ | Resolve-TeamViewerManagedGroupId } )]
+        [Alias("ManagedGroupId")]
+        [object]
+        $ManagedGroup,
+
         [switch]
         $RemovePolicy
     )
@@ -35,10 +40,19 @@ function Set-TeamViewerManagedDevice {
         elseif ($RemovePolicy) {
             $body['teamviewerPolicyId'] = ""
         }
+        elseif ($ManagedGroup) {
+            $body['managedGroupId'] = $ManagedGroup | Resolve-TeamViewerManagedGroupId
+        }
 
         if ($Policy -And $RemovePolicy) {
             $PSCmdlet.ThrowTerminatingError(
                 ("Parameters -Policy and -RemovePolicy cannot be used together." | `
+                        ConvertTo-ErrorRecord -ErrorCategory InvalidArgument))
+        }
+
+        if (($Policy -or $RemovePolicy) -And $ManagedGroup) {
+            $PSCmdlet.ThrowTerminatingError(
+                ("The combination of parameters -Policy, -PolicyRemove and -ManagedGroup is not allowed." | `
                         ConvertTo-ErrorRecord -ErrorCategory InvalidArgument))
         }
 

--- a/TeamViewerPS/TeamViewerPS.Types.ps1
+++ b/TeamViewerPS/TeamViewerPS.Types.ps1
@@ -3,3 +3,9 @@ enum TeamViewerConnectionReportSessionType {
     RemoteSupportActive = 2
     RemoteSupportActiveSdk = 3
 }
+
+enum PolicyType {
+    TeamViewer = 1
+    Monitoring = 4
+    PatchManagement = 5
+}

--- a/Tests/Public/Remove-TeamViewerPolicyFromManagedDevice.Tests.ps1
+++ b/Tests/Public/Remove-TeamViewerPolicyFromManagedDevice.Tests.ps1
@@ -1,0 +1,55 @@
+BeforeAll {
+    . "$PSScriptRoot/../../TeamViewerPS/Public/Remove-TeamViewerPolicyFromManagedDevice.ps1"
+    . "$PSScriptRoot/../../TeamViewerPS/TeamViewerPS.Types.ps1"
+
+    @(Get-ChildItem -Path "$PSScriptRoot/../../TeamViewerPS/Private/*.ps1") | `
+        ForEach-Object { . $_.FullName }
+
+    $testApiToken = [securestring]@{}
+    $null = $testApiToken
+    $testDeviceId = '9e5617cb-2b20-4da2-bca4-c1bda85b29ab'
+    $null = $testDeviceId
+
+    Mock Get-TeamViewerApiUri { '//unit.test' }
+    $mockArgs = @{}
+    Mock Invoke-TeamViewerRestMethod { $mockArgs.Body = $Body }
+}
+
+Describe 'Remove-TeamViewerPolicyFromManagedDevice' {
+
+    It 'Should call the correct API endpoint to remove a policy from the managed device' {
+        Remove-TeamViewerPolicyFromManagedDevice -ApiToken $testApiToken -Device $testDeviceId -PolicyType TeamViewer
+        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+            $ApiToken -eq $testApiToken -And `
+                $Uri -eq "//unit.test/managed/devices/$testDeviceId/policy/remove" -And `
+                $Method -eq 'Put' }
+    }
+
+    It 'should remove teamviewer policy from managed device' {
+        Remove-TeamViewerPolicyFromManagedDevice -apitoken $testapitoken -device $testdeviceid -Policytype TeamViewer
+        $mockargs.body | Should -Not -BeNullOrEmpty
+        $body = [system.text.encoding]::utf8.getstring($mockargs.body) | ConvertFrom-Json
+        $body.policy_type | Should -Be 1
+    }
+
+    It 'should remove monitoring policy from managed device' {
+        Remove-TeamViewerPolicyFromManagedDevice -apitoken $testapitoken -device $testdeviceid -PolicyType Monitoring
+        $mockargs.body | Should -Not -BeNullOrEmpty
+        $body = [system.text.encoding]::utf8.getstring($mockargs.body) | ConvertFrom-Json
+        $body.policy_type | Should -Be 4
+    }
+
+    It 'should remove patch management policy from managed device' {
+        Remove-TeamViewerPolicyFromManagedDevice -apitoken $testapitoken -device $testdeviceid -PolicyType PatchManagement
+        $mockargs.body | Should -Not -BeNullOrEmpty
+        $body = [system.text.encoding]::utf8.getstring($mockargs.body) | ConvertFrom-Json
+        $body.policy_type | Should -Be 5
+    }
+
+    It 'Should throw an error when called with invalid policy type' {
+        { Remove-TeamViewerPolicyFromManagedDevice `
+                -ApiToken $testApiToken `
+                -Device $testDeviceId -PolicyType 2 } | Should -Throw
+    }
+}
+

--- a/Tests/Public/Set-TeamViewerManagedDevice.Tests.ps1
+++ b/Tests/Public/Set-TeamViewerManagedDevice.Tests.ps1
@@ -45,11 +45,34 @@ Describe 'Set-TeamViewerManagedDevice' {
         $body.teamviewerPolicyId | Should -Be ''
     }
 
+    It 'Should update the managed device policy to the managed group' {
+        Set-TeamViewerManagedDevice -ApiToken $testApiToken -Device $testDeviceId -ManagedGroup 'e579cfeb-0b29-4d91-9e81-2d9507f53ff8'
+        $mockArgs.Body | Should -Not -BeNullOrEmpty
+        $body = [System.Text.Encoding]::UTF8.GetString($mockArgs.Body) | ConvertFrom-Json
+        $body.managedGroupId | Should -Be 'e579cfeb-0b29-4d91-9e81-2d9507f53ff8'
+    }
+
     It 'Should not be possible to set and remove the policy at the same time' {
         { Set-TeamViewerManagedDevice `
                 -ApiToken $testApiToken `
                 -Device $testDeviceId `
                 -Policy '2871c013-3040-4969-9ba4-ce970f4375e8' `
+                -RemovePolicy } | Should -Throw
+    }
+
+    It 'Should not be possible to inherit and set a policy at the same time' {
+        { Set-TeamViewerManagedDevice `
+                -ApiToken $testApiToken `
+                -Device $testDeviceId `
+                -Policy '2871c013-3040-4969-9ba4-ce970f4375e8' `
+                -ManagedGroup '6808db5b-f3c1-4e42-8168-3ac96f5d456e' } | Should -Throw
+    }
+
+    It 'Should not be possible to inherit and remove a policy at the same time' {
+        { Set-TeamViewerManagedDevice `
+                -ApiToken $testApiToken `
+                -Device $testDeviceId `
+                -ManagedGroup '2871c013-3040-4969-9ba4-ce970f4375e8' `
                 -RemovePolicy } | Should -Throw
     }
 

--- a/docs/commands/Remove-TeamViewerPolicyFromManagedDevice.md
+++ b/docs/commands/Remove-TeamViewerPolicyFromManagedDevice.md
@@ -1,0 +1,157 @@
+---
+external help file: TeamViewerPS-help.xml
+Module Name: TeamViewerPS
+online version: [Link to Online Documentation]
+schema: 2.0.0
+---
+
+# Remove-TeamViewerPolicyFromManagedDevice
+
+## SYNOPSIS
+
+Remove a policy from a managed device based on type.
+
+Valid Types are:
+
+- TeamViewer
+- Monitoring
+- PatchManagement
+
+## SYNTAX
+
+```powershell
+Remove-TeamViewerPolicyFromManagedDevice -ApiToken <SecureString> -Device <Object> -PolicyType <PolicyType> [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+Remove a specified policy from a managed device.
+
+## EXAMPLES
+
+### Example 1
+
+Remove TeamViewer policy from device
+
+```powershell
+PS /> Remove-TeamViewerPolicyFromManagedDevice -Device 'd8773208-a685-4323-9de5-7f86951f8c30' -PolicyType 1
+```
+
+```powershell
+PS /> Remove-TeamViewerPolicyFromManagedDevice -Device 'd8773208-a685-4323-9de5-7f86951f8c30' -PolicyType TeamViewer
+```
+
+### Example 2
+
+Remove Monitoring policy from device
+
+```powershell
+PS /> Remove-TeamViewerPolicyFromManagedDevice -Device '730ee15a-1ea4-4d80-9cfe-5a01709d0a2f' -PolicyType 4
+```
+
+```powershell
+PS /> Remove-TeamViewerPolicyFromManagedDevice -Device '730ee15a-1ea4-4d80-9cfe-5a01709d0a2f' -PolicyType Monitoring
+```
+
+### Example 3
+
+Remove PatchManagement policy from device
+
+```powershell
+PS /> Remove-TeamViewerPolicyFromManagedDevice -Device '730ee15a-1ea4-4d80-9cfe-5a01709d0a2f' -PolicyType 5
+```
+
+```powershell
+PS /> Remove-TeamViewerPolicyFromManagedDevice -Device '730ee15a-1ea4-4d80-9cfe-5a01709d0a2f' -PolicyType PatchManagement
+```
+
+## PARAMETERS
+
+### -ApiToken
+
+The TeamViewer API access token.
+
+```yaml
+Type: SecureString
+Parameter Sets: (All)
+Aliases:
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Device
+
+The managed device from which you want to remove the policy.
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases: DeviceId
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -PolicyType
+
+The type of policy to remove from the managed device.
+
+```yaml
+Type: PolicyType (Enum)
+Parameter Sets: (All)
+Aliases:
+Required: True
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+
+Shows what would happen if the cmdlet runs. The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.Object
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS

--- a/docs/commands/Set-TeamViewerManagedDevice.md
+++ b/docs/commands/Set-TeamViewerManagedDevice.md
@@ -15,7 +15,7 @@ Change properties of a TeamViewer managed device.
 
 ```powershell
 Set-TeamViewerManagedDevice [-ApiToken] <SecureString> [-Device] <Object> [[-Name] <String>]
- [[-Policy] <Object>] [-RemovePolicy] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-Policy] <Object>] [-RemovePolicy] [[-ManagedGroup] <Object>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -53,7 +53,15 @@ Sets the policy of the device.
 PS /> Set-TeamViewerManagedDevice -Device '33a2e2e1-27ef-43e2-a175-f97ee0344033' -RemovePolicy
 ```
 
-Removes the policy from the managed device.
+Removes the TeamViewer policy of the device.
+
+### Example 3
+
+```powershell
+PS /> Set-TeamViewerManagedDevice -Device '33a2e2e1-27ef-43e2-a175-f97ee0344033' -ManagedGroup '730ee15a-1ea4-4d80-9cfe-5a01709d0a2f'
+```
+
+Inherit the TeamViewer policy from a managed group to the device (the device has to be part of the managed group specified).
 
 ## PARAMETERS
 
@@ -158,6 +166,24 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ManagedGroup
+
+Object that can be used to identify the managed group.
+This can either be the managed group ID (as string or GUID) or a managed group
+object that has been received using other module functions.
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases: ManagedGroupId
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 


### PR DESCRIPTION
- Added [Remove-TeamViewerPolicyFromManagedDevice.ps1](https://github.com/teamviewer/TeamViewerPS/pull/29/commits/c412b79879e43a2acc61d904bb5288a2f150ea4c#diff-c0b34019e2484bd48a8acefc9f788565fec636c7ddbea6a4ce7fd5496c05ba5e) to allow for managed devices policy removal.
- Updated [Set-TeamViewerManagedDevice.ps1](https://github.com/teamviewer/TeamViewerPS/pull/29/commits/c412b79879e43a2acc61d904bb5288a2f150ea4c#diff-bed0156baef08162d7c8cc36152e2493690303f4866fd7dfbd56a72a1b808f04) to allow for managed devices policy inheritance from managed group.
- Added and updated tests.