### PR TITLE
Remove old company permissions from user

### DIFF
--- a/.vscode/spelling
+++ b/.vscode/spelling
@@ -1,6 +1,7 @@
-// TeamViewerPS
+// Project
 TeamViewer
 TeamViewer's
+TeamViewerPS
 
 // Powershell
 cmdlet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,71 +4,76 @@
 
 ### Added
 
-- Added 'Set-TeamViewerApiURi' to use TeamViewer test API.
-- Added user role commands to remotely manage user roles of a TeamViewer company.
-- Added `Add-TeamViewerAssignment` and `Remove-TeamViewerAssignment` commands to assign and unassign a device from a TeamViewer company.
-- Added `Add-TeamViewerCustomization` and `Remove-TeamViewerCustomization` commands to apply and remove customization.
-- Added `Export-TeamViewerSystemInformation` to create zip file for support.
-- Added `Set-TeamViewerPSProxy` and `Remove-TeamViewerPSProxy` to set proxy to access WebAPI.
-- Added `Get-TeamViewerInstallationDirectory` to return installation directory.
-- Added `Remove-TeamViewerPolicyFromManagedDevice` to remove policies from managed devices.
+- Adds user role commands to manage user roles of a TeamViewer company.
+- Adds `Set-TeamViewerApiURi` to use TeamViewer test API.
+- Adds `Add-TeamViewerAssignment` and `Remove-TeamViewerAssignment` commands to assign and unassign a device from a TeamViewer company.
+- Adds `Add-TeamViewerCustomization` and `Remove-TeamViewerCustomization` commands to apply and remove customization.
+- Adds `Export-TeamViewerSystemInformation` to create zip file for support.
+- Adds `Set-TeamViewerPSProxy` and `Remove-TeamViewerPSProxy` to set proxy to access WebAPI.
+- Adds `Get-TeamViewerInstallationDirectory` to return installation directory.
+- Adds `Remove-TeamViewerPolicyFromManagedDevice` to remove policies from managed devices.
   
 ### Changed
   
-- Extended `Invoke-TeamViewerPackageDownload` with MSI package type.
-- Folder structure modified.
-- `-RemovePolicy` switch removed from `Set-TeamViewerManagedDevice`.
+- Extends `Invoke-TeamViewerPackageDownload` with MSI package type.
+- Modifies general folder structure.
+- Removes `-RemovePolicy` switch from `Set-TeamViewerManagedDevice`.
 
 ### Fixed
   
-- Fixed `Get-TeamViewerLinuxGlobalConfig` to handle null values.
+- Fixes `Get-TeamViewerLinuxGlobalConfig` to handle null values.
 
 ## 1.5.2 (2023-09-18)
 
-- Remove-TeamViewerPolicyFromManagedDevice has been added.
-- ManagedGroupId parameter has been added to Set-TeamViewerManagedDevice.
+### Added
+
+- Adds `Remove-TeamViewerPolicyFromManagedDevice` to remove a policy from a managed device.
+
+### Changed
+
+- Adds `ManagedGroupId` parameter to `Set-TeamViewerManagedDevice`.
 
 ## 1.5.1 (2023-07-18)
 
-- Improved `User ID` parameter handling for `Add-TeamViewerUserGroupMember` and `Remove-TeamViewerUserGroupMember`
+- Improves `User ID` parameter handling for `Add-TeamViewerUserGroupMember` and `Remove-TeamViewerUserGroupMember`.
 
 ## 1.5.0 (2023-05-24)
 
 ### Added
 
-- Added `Remove-TeamViewerUser` cmdlet to remove user from TeamViewer company. (Thanks @OtterKring)
-- Added `Remove-TeamViewerManagedDeviceManagement` to unmanage a device.
+- Adds `Remove-TeamViewerUser` cmdlet to remove user from TeamViewer company. (Thanks @OtterKring)
+- Adds `Remove-TeamViewerManagedDeviceManagement` to un-manage a device.
 
 ### Changed
 
-- Extended `Add-TeamViewerManager` to add user group as manager. (Thanks @OtterKring)
-- Extended `TeamViewerManagedDevice` to have "LastSeenAt" available for managed devices
+- Extends `Add-TeamViewerManager` to add user group as manager. (Thanks @OtterKring)
+- Adds `LastSeenAt` to `TeamViewerManagedDevice` for managed devices.
 
 ## 1.4.0 (2022-04-19)
 
-### Fixed
-
-- Fixed `-Group` parameter of `Remove-TeamViewerManagedDevice` to be mandatory.
-
 ### Added
 
-- Added `Get-TeamViewerConnectionReport` cmdlet to fetch TeamViewer session/connection reports.
+- Adds `Get-TeamViewerConnectionReport` cmdlet to fetch TeamViewer session / connection reports.
+
+### Fixed
+
+- Fixes `-Group` parameter of `Remove-TeamViewerManagedDevice` to be mandatory.
 
 ## 1.3.1 (2021-11)
 
-### Fixed
-
-- Fixed `Set-TeamViewerPolicy` to support changing policy settings.
-
 ### Changed
 
-- Result of `Get-TeamViewerUser` now also includes license information.
+- `Get-TeamViewerUser` includes license information.
+
+### Fixed
+
+- Fixes `Set-TeamViewerPolicy` to support changing policy settings.
 
 ## 1.3.0 (2021-11-29)
 
 ### Added
 
-- Adds command `Get-TeamViewerEventLog` to fetch event log entries.
+- Adds `Get-TeamViewerEventLog` to fetch event log entries.
 - Adds user group commands to remotely manage user groups of a TeamViewer company.
 
 ## 1.2.0 (2021-07-19)
@@ -77,8 +82,7 @@
 
 - Adds command `Set-TeamViewerManagedDevice` to change properties of a managed device.
 - Adds optional `Policy` property to `Get-TeamViewerManagedDevice` result entries.
-- Adds `-Device` parameter to `Get-TeamViewerManagedGroup` command, allowing to
-  fetch all managed groups that a particular device is part of.
+- Adds `-Device` parameter to `Get-TeamViewerManagedGroup` command, allowing to fetch all managed groups that a particular device is part of.
 
 ## 1.1.0 (2021-04-15)
 
@@ -89,7 +93,7 @@
 
 ### Changed
 
-- Improved bulk support for `Add-TeamViewerSsoExclusion` and `Remove-TeamViewerSsoExclusion`.
+- Improves bulk support for `Add-TeamViewerSsoExclusion` and `Remove-TeamViewerSsoExclusion`.
 
 ## 1.0.0 (2021-01-15)
 

--- a/Cmdlets/Private/ConvertTo-TeamViewerUser.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerUser.ps1
@@ -8,18 +8,20 @@ function ConvertTo-TeamViewerUser {
         [ValidateSet('All', 'Minimal')]
         $PropertiesToLoad = 'All'
     )
+
     process {
         $properties = @{
             Id    = $InputObject.id
             Name  = $InputObject.name
             Email = $InputObject.email
         }
+
         if ($PropertiesToLoad -Eq 'All') {
             $properties += @{
-                Permissions    = $InputObject.permissions -split ','
                 Active         = $InputObject.active
                 LastAccessDate = $InputObject.last_access_date | ConvertTo-DateTime
             }
+
             if ($InputObject.activated_license_id) {
                 $properties += @{
                     ActivatedLicenseId      = [guid]$InputObject.activated_license_id
@@ -27,17 +29,20 @@ function ConvertTo-TeamViewerUser {
                     ActivatedSubLicenseName = $InputObject.activated_subLicense_name
                 }
             }
+
             if ($InputObject.activated_meeting_license_key) {
                 $properties += @{
                     ActivatedMeetingLicenseId = [guid]$InputObject.activated_meeting_license_key
                 }
             }
         }
+
         $result = New-Object -TypeName PSObject -Property $properties
         $result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.User')
-        $result | Add-Member -MemberType ScriptMethod -Name "ToString" -Force -Value {
+        $result | Add-Member -MemberType ScriptMethod -Name 'ToString' -Force -Value {
             Write-Output "$($this.Name) <$($this.Email)>"
         }
+
         Write-Output $result
     }
 }

--- a/Cmdlets/Public/Get-TeamViewerUser.ps1
+++ b/Cmdlets/Public/Get-TeamViewerUser.ps1
@@ -1,69 +1,61 @@
 function Get-TeamViewerUser {
-    [CmdletBinding(DefaultParameterSetName = "FilteredList")]
+    [CmdletBinding(DefaultParameterSetName = 'FilteredList')]
     param(
         [Parameter(Mandatory = $true)]
         [securestring]
         $ApiToken,
 
-        [Parameter(ParameterSetName = "ByUserId")]
+        [Parameter(ParameterSetName = 'ByUserId')]
         [ValidateScript( { $_ | Resolve-TeamViewerUserId } )]
-        [Alias("UserId")]
+        [Alias('UserId')]
         [string]
         $Id,
 
-        [Parameter(ParameterSetName = "FilteredList")]
-        [Alias("PartialName")]
+        [Parameter(ParameterSetName = 'FilteredList')]
+        [Alias('PartialName')]
         [string]
         $Name,
 
-        [Parameter(ParameterSetName = "FilteredList")]
+        [Parameter(ParameterSetName = 'FilteredList')]
         [string[]]
         $Email,
 
-        [Parameter(ParameterSetName = "FilteredList")]
-        [string[]]
-        $Permissions,
-
         [Parameter()]
-        [ValidateSet("All", "Minimal")]
-        $PropertiesToLoad = "All"
+        [ValidateSet('All', 'Minimal')]
+        $PropertiesToLoad = 'All'
     )
 
     $parameters = @{ }
     switch ($PropertiesToLoad) {
-        "All" { $parameters.full_list = $true }
-        "Minimal" { }
+        'All' {
+            $parameters.full_list = $true 
+        }
+        'Minimal' { 
+        }
     }
 
     $resourceUri = "$(Get-TeamViewerApiUri)/users"
 
     switch ($PsCmdlet.ParameterSetName) {
-        "ByUserId" {
+        'ByUserId' {
             $resourceUri += "/$Id"
             $parameters = $null
         }
-        "FilteredList" {
+        'FilteredList' {
             if ($Name) {
                 $parameters['name'] = $Name
             }
+
             if ($Email) {
                 $parameters['email'] = ($Email -join ',')
-            }
-            if ($Permissions) {
-                $parameters['permissions'] = ($Permissions -join ',')
             }
         }
     }
 
     $response = Invoke-TeamViewerRestMethod `
-        -ApiToken $ApiToken `
-        -Uri $resourceUri `
-        -Method Get `
-        -Body $parameters `
-        -WriteErrorTo $PSCmdlet `
-        -ErrorAction Stop
+        -ApiToken $ApiToken -Uri $resourceUri -Method Get -Body $parameters -WriteErrorTo $PSCmdlet -ErrorAction Stop
 
-    if ($PsCmdlet.ParameterSetName -Eq "ByUserId") {
+    if ($PsCmdlet.ParameterSetName -Eq 'ByUserId') {
         Write-Output ($response | ConvertTo-TeamViewerUser -PropertiesToLoad $PropertiesToLoad)
     }
     else {

--- a/Cmdlets/Public/New-TeamViewerUser.ps1
+++ b/Cmdlets/Public/New-TeamViewerUser.ps1
@@ -1,5 +1,5 @@
 function New-TeamViewerUser {
-    [CmdletBinding(SupportsShouldProcess = $true, DefaultParameterSetName = "WithPassword")]
+    [CmdletBinding(SupportsShouldProcess = $true, DefaultParameterSetName = 'WithPassword')]
     param(
         [Parameter(Mandatory = $true)]
         [securestring]
@@ -15,11 +15,11 @@ function New-TeamViewerUser {
         [string]
         $Name,
 
-        [Parameter(Mandatory = $true, ParameterSetName = "WithPassword")]
+        [Parameter(Mandatory = $true, ParameterSetName = 'WithPassword')]
         [securestring]
         $Password,
 
-        [Parameter(ParameterSetName = "WithoutPassword")]
+        [Parameter(ParameterSetName = 'WithoutPassword')]
         [Alias('NoPassword')]
         [switch]
         $WithoutPassword,
@@ -29,25 +29,24 @@ function New-TeamViewerUser {
         $SsoCustomerIdentifier,
 
         [Parameter()]
-        [array]
-        $Permissions,
-
-        [Parameter()]
         [ValidateScript( { $_ | Resolve-TeamViewerLanguage } )]
         [cultureinfo]
         $Culture
     )
 
     if (-Not $Culture) {
-        try { $Culture = Get-Culture }
-        catch { $Culture = 'en' }
+        try {
+            $Culture = Get-Culture 
+        }
+        catch {
+            $Culture = 'en' 
+        }
     }
 
     $body = @{
-        email       = $Email
-        name        = $Name
-        language    = $Culture | Resolve-TeamViewerLanguage
-        permissions = $Permissions -join ','
+        email    = $Email
+        name     = $Name
+        language = $Culture | Resolve-TeamViewerLanguage
     }
 
     if ($Password -And -Not $WithoutPassword) {
@@ -63,18 +62,12 @@ function New-TeamViewerUser {
     }
 
     $resourceUri = "$(Get-TeamViewerApiUri)/users"
-    if ($PSCmdlet.ShouldProcess("$Name <$Email>", "Create user")) {
-        $response = Invoke-TeamViewerRestMethod `
-            -ApiToken $ApiToken `
-            -Uri $resourceUri `
-            -Method Post `
-            -ContentType "application/json; charset=utf-8" `
-            -Body ([System.Text.Encoding]::UTF8.GetBytes(($body | ConvertTo-Json))) `
-            -WriteErrorTo $PSCmdlet `
-            -ErrorAction Stop
-
+    if ($PSCmdlet.ShouldProcess("$Name <$Email>", 'Create user')) {
+        $response = Invoke-TeamViewerRestMethod -ApiToken $ApiToken -Uri $resourceUri -Method Post -ContentType 'application/json; charset=utf-8' `
+            -Body ([System.Text.Encoding]::UTF8.GetBytes(($body | ConvertTo-Json))) -WriteErrorTo $PSCmdlet -ErrorAction Stop
         $result = ($response | ConvertTo-TeamViewerUser)
         $result.Email = $Email
+
         Write-Output $result
     }
 }

--- a/Cmdlets/Public/Set-TeamViewerUser.ps1
+++ b/Cmdlets/Public/Set-TeamViewerUser.ps1
@@ -7,8 +7,8 @@ function Set-TeamViewerUser {
 
         [Parameter(Mandatory = $true)]
         [ValidateScript( { $_ | Resolve-TeamViewerUserId } )]
-        [Alias("UserId")]
-        [Alias("Id")]
+        [Alias('UserId')]
+        [Alias('Id')]
         [object]
         $User,
 
@@ -33,10 +33,6 @@ function Set-TeamViewerUser {
         [Parameter(ParameterSetName = 'ByParameters')]
         [securestring]
         $SsoCustomerIdentifier,
-
-        [Parameter(ParameterSetName = 'ByParameters')]
-        [array]
-        $Permissions,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'ByProperties')]
         [hashtable]
@@ -65,34 +61,23 @@ function Set-TeamViewerUser {
                 $body['sso_customer_id'] = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($bstr)
                 [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr) | Out-Null
             }
-            if ($Permissions) {
-                $body['permissions'] = $Permissions -join ','
-            }
         }
         'ByProperties' {
-            @('active', 'email', 'name', 'password', 'sso_customer_id', 'permissions') | `
-                Where-Object { $Property[$_] } | `
-                ForEach-Object { $body[$_] = $Property[$_] }
+            @('active', 'email', 'name', 'password', 'sso_customer_id') | Where-Object { $Property[$_] } | ForEach-Object { $body[$_] = $Property[$_] }
         }
     }
 
     if ($body.Count -eq 0) {
         $PSCmdlet.ThrowTerminatingError(
-            ("The given input does not change the user." | `
-                    ConvertTo-ErrorRecord -ErrorCategory InvalidArgument))
+            ('The given input does not change the user.' | `
+                ConvertTo-ErrorRecord -ErrorCategory InvalidArgument))
     }
 
     $userId = Resolve-TeamViewerUserId -User $User
     $resourceUri = "$(Get-TeamViewerApiUri)/users/$userId"
 
-    if ($PSCmdlet.ShouldProcess($userId, "Update user profile")) {
-        Invoke-TeamViewerRestMethod `
-            -ApiToken $ApiToken `
-            -Uri $resourceUri `
-            -Method Put `
-            -ContentType "application/json; charset=utf-8" `
-            -Body ([System.Text.Encoding]::UTF8.GetBytes(($body | ConvertTo-Json))) `
-            -WriteErrorTo $PSCmdlet | `
-            Out-Null
+    if ($PSCmdlet.ShouldProcess($userId, 'Update user profile')) {
+        Invoke-TeamViewerRestMethod -ApiToken $ApiToken -Uri $resourceUri -Method Put -ContentType 'application/json; charset=utf-8' `
+            -Body ([System.Text.Encoding]::UTF8.GetBytes(($body | ConvertTo-Json))) -WriteErrorTo $PSCmdlet | Out-Null
     }
 }

--- a/Docs/Help/Get-TeamViewerUser.md
+++ b/Docs/Help/Get-TeamViewerUser.md
@@ -16,8 +16,7 @@ Retrieve users of a TeamViewer company.
 ### FilteredList (Default)
 
 ```powershell
-Get-TeamViewerUser -ApiToken <SecureString> [-Name <String>] [-Email <String[]>] [-Permissions <String[]>]
- [-PropertiesToLoad <Object>] [<CommonParameters>]
+Get-TeamViewerUser -ApiToken <SecureString> [-Name <String>] [-Email <String[]>] [-PropertiesToLoad <Object>] [<CommonParameters>]
 ```
 
 ### ByUserId
@@ -78,8 +77,7 @@ Accept wildcard characters: False
 
 ### -Email
 
-Optional list of email addresses. Can be used to only return users that exactly
-match one of the given email addresses.
+Optional list of email addresses. Can be used to only return users that exactly match one of the given email addresses.
 
 ```yaml
 Type: String[]
@@ -111,8 +109,7 @@ Accept wildcard characters: False
 
 ### -Name
 
-Optional name filter parameter that can be used to only list users that have
-the given string in their name.
+Optional name filter parameter that can be used to only list users that have the given string in their name.
 
 ```yaml
 Type: String
@@ -126,27 +123,9 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Permissions
-
-Optional permissions filter that can be used to only list users that have
-certain permissions. Multiple values can be given.
-
-```yaml
-Type: String[]
-Parameter Sets: FilteredList
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -PropertiesToLoad
 
-Can be used to retrieve all available properties of a user or just a
-stripped-down minimal set of user properties.
+Can be used to retrieve all available properties of a user or just a stripped-down minimal set of user properties.
 
 ```yaml
 Type: Object

--- a/Docs/Help/New-TeamViewerUser.md
+++ b/Docs/Help/New-TeamViewerUser.md
@@ -17,16 +17,14 @@ Create a new TeamViewer company user.
 
 ```powershell
 New-TeamViewerUser -ApiToken <SecureString> -Email <String> -Name <String> -Password <SecureString>
- [-SsoCustomerIdentifier <SecureString>] [-Permissions <Array>] [-Culture <CultureInfo>] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+ [-SsoCustomerIdentifier <SecureString>] [-Culture <CultureInfo>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### WithoutPassword
 
 ```powershell
 New-TeamViewerUser -ApiToken <SecureString> -Email <String> -Name <String> [-WithoutPassword]
- [-SsoCustomerIdentifier <SecureString>] [-Permissions <Array>] [-Culture <CultureInfo>] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+ [-SsoCustomerIdentifier <SecureString>] [-Culture <CultureInfo>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -41,8 +39,7 @@ Creates a new user for the company that is associated to the API access token.
 PS /> New-TeamViewerUser -Email 'test@example.test' -Name 'Test User'
 ```
 
-Create a new user with the given email address and name. The password will be
-prompted.
+Create a new user with the given email address and name. The password will be prompted.
 
 ### Example 2
 
@@ -50,9 +47,8 @@ prompted.
 PS /> New-TeamViewerUser -Email 'test@example.test' -Name 'Test User' -WithoutPassword
 ```
 
-Create a new user with the given email address and name. It will be created
-without a password. The user must reset the password through the TeamViewer
-web page.
+Create a new user with the given email address and name.
+It will be created without a password. The user must reset the password through the TeamViewer web page.
 
 ## PARAMETERS
 
@@ -146,22 +142,6 @@ Parameter Sets: WithPassword
 Aliases:
 
 Required: True
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Permissions
-
-Optional list of permissions to give to the new user.
-
-```yaml
-Type: Array
-Parameter Sets: (All)
-Aliases:
-
-Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/Docs/Help/Set-TeamViewerUser.md
+++ b/Docs/Help/Set-TeamViewerUser.md
@@ -17,15 +17,13 @@ Change properties of a TeamViewer company user.
 
 ```powershell
 Set-TeamViewerUser -ApiToken <SecureString> -User <Object> [-Active <Boolean>] [-Email <String>]
- [-Name <String>] [-Password <SecureString>] [-SsoCustomerIdentifier <SecureString>] [-Permissions <Array>]
- [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-Name <String>] [-Password <SecureString>] [-SsoCustomerIdentifier <SecureString>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ByProperties
 
 ```powershell 
-Set-TeamViewerUser -ApiToken <SecureString> -User <Object> -Property <Hashtable> [-WhatIf] [-Confirm]
- [<CommonParameters>]
+Set-TeamViewerUser -ApiToken <SecureString> -User <Object> -Property <Hashtable> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -66,8 +64,7 @@ PS /> $ssoCustomerIdentifier = ("abc" | ConvertTo-SecureString -AsPlainText -For
 PS /> Set-TeamViewerUser -UserId 'u1234' -SsoCustomerIdentifier $ssoCustomerIdentifier
 ```
 
-Do the SSO activation step for the given user. This can also be used to repair a possibly broken
-SSO login token for that user.
+Do the SSO activation step for the given user. This can also be used to repair a possibly broken SSO login token for that user.
 
 ## PARAMETERS
 
@@ -167,28 +164,11 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Permissions
-
-Updated set of permissions of the company user.
-Please see the TeamViewer API documentation for a list of valid values.
-
-```yaml
-Type: Array
-Parameter Sets: ByParameters
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -Property
 
 Change policy information using a hashtable object.
 Valid hashtable keys are:
-`active`, `email`, `name`, `password`, `sso_customer_id`, `permissions`
+`active`, `email`, `name`, `password`, `sso_customer_id`
 
 ```yaml
 Type: Hashtable
@@ -204,9 +184,8 @@ Accept wildcard characters: False
 
 ### -SsoCustomerIdentifier
 
-Optional TeamViewer SSO customer identifier. If given, the user will be updated
-with SSO activation step already done. With this option, the user must not
-enter the TeamViewer password at when doing Single Sign-On.
+Optional TeamViewer SSO customer identifier. If given, the user will be updated with SSO activation step already done.
+With this option, the user must not enter the TeamViewer password at when doing Single Sign-On.
 
 ```yaml
 Type: SecureString
@@ -223,8 +202,7 @@ Accept wildcard characters: False
 ### -User
 
 Object that can be used to identify the user.
-This can either be the user ID or a user object that has been received using
-other module functions.
+This can either be the user ID or a user object that has been received using other module functions.
 
 ```yaml
 Type: Object

--- a/Tests/Public/Get-TeamViewerUser.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerUser.Tests.ps1
@@ -1,8 +1,7 @@
 BeforeAll {
     . "$PSScriptRoot\..\..\Cmdlets\Public\Get-TeamViewerUser.ps1"
 
-    @(Get-ChildItem -Path "$PSScriptRoot\..\..\Cmdlets\Private\*.ps1") | `
-        ForEach-Object { . $_.FullName }
+    @(Get-ChildItem -Path "$PSScriptRoot\..\..\Cmdlets\Private\*.ps1") | ForEach-Object { . $_.FullName }
 
     $testApiToken = [securestring]@{}
     $null = $testApiToken
@@ -23,18 +22,14 @@ Describe 'Get-TeamViewerUser' {
         Get-TeamViewerUser -ApiToken $testApiToken
 
         Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
-            $ApiToken -eq $testApiToken -And `
-                $Uri -eq '//unit.test/users' -And `
-                $Method -eq 'Get' }
+            $ApiToken -eq $testApiToken -And $Uri -eq '//unit.test/users' -And $Method -eq 'Get' }
     }
 
     It 'Should call the correct API endpoint for single user' {
         Get-TeamViewerUser -ApiToken $testApiToken -User 'u1234'
 
         Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
-            $ApiToken -eq $testApiToken -And `
-                $Uri -eq '//unit.test/users/u1234' -And `
-                $Method -eq 'Get' }
+            $ApiToken -eq $testApiToken -And $Uri -eq '//unit.test/users/u1234' -And $Method -eq 'Get' }
     }
 
     It 'Should return User objects' {
@@ -45,30 +40,28 @@ Describe 'Get-TeamViewerUser' {
 
     It 'Should allow to filter by name' {
         Get-TeamViewerUser -ApiToken $testApiToken -Name 'TestName'
+
         Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $Body -And $Body['name'] -eq 'TestName' }
     }
 
     It 'Should allow to filter by emails' {
         Get-TeamViewerUser -ApiToken $testApiToken -Email 'user1@unit.test', 'user2@unit.test'
+
         Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $Body -And $Body['email'] -eq 'user1@unit.test,user2@unit.test' }
     }
 
-    It 'Should allow to filter by permissions' {
-        Get-TeamViewerUser -ApiToken $testApiToken -Permissions 'p1', 'p2', 'p3'
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
-            $Body -And $Body['permissions'] -eq 'p1,p2,p3' }
-    }
-
     It 'Should allow to retrieve all properties' {
         Get-TeamViewerUser -ApiToken $testApiToken -PropertiesToLoad 'All'
+
         Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $Body -And $Body['full_list'] -eq $true }
     }
 
     It 'Should allow to retrieve a minimal set of properties' {
         Get-TeamViewerUser -ApiToken $testApiToken -PropertiesToLoad 'Minimal'
+
         Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $Body -And $Body['full_list'] -eq $null }
     }

--- a/Tests/Public/New-TeamViewerUser.Tests.ps1
+++ b/Tests/Public/New-TeamViewerUser.Tests.ps1
@@ -15,7 +15,9 @@ BeforeAll {
         # We do this only for testing
         [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
         param()
-        Process { $_ | ConvertTo-SecureString -AsPlainText -Force }
+        Process {
+            $_ | ConvertTo-SecureString -AsPlainText -Force 
+        }
     }
 }
 
@@ -25,9 +27,7 @@ Describe 'New-TeamViewerUser' {
         New-TeamViewerUser -ApiToken $testApiToken -Name 'Unit Test User' -Email 'user1@unit.test' -WithoutPassword
 
         Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
-            $ApiToken -eq $testApiToken -And `
-                $Uri -eq '//unit.test/users' -And `
-                $Method -eq 'Post' }
+            $ApiToken -eq $testApiToken -And $Uri -eq '//unit.test/users' -And $Method -eq 'Post' }
     }
 
     It 'Should include the given name and email in the request' {
@@ -64,6 +64,7 @@ Describe 'New-TeamViewerUser' {
 
     It 'Should allow to specify a password for the new user' {
         $testPassword = 'Test1234' | ConvertTo-TestPassword
+
         New-TeamViewerUser -ApiToken $testApiToken -Name 'Unit Test User' -Email 'user1@unit.test' -Password $testPassword
 
         $mockArgs.Body | Should -Not -BeNullOrEmpty
@@ -73,6 +74,7 @@ Describe 'New-TeamViewerUser' {
 
     It 'Should allow to create a SSO-enabled user' {
         $testSsoCustomerId = 'my-sso-customer-id' | ConvertTo-TestPassword
+
         New-TeamViewerUser -ApiToken $testApiToken -Name 'Unit Test User' -Email 'user1@unit.test' -WithoutPassword -SsoCustomerIdentifier $testSsoCustomerId
 
         $mockArgs.Body | Should -Not -BeNullOrEmpty

--- a/Tests/Public/Set-TeamViewerUser.Tests.ps1
+++ b/Tests/Public/Set-TeamViewerUser.Tests.ps1
@@ -1,8 +1,7 @@
 BeforeAll {
     . "$PSScriptRoot\..\..\Cmdlets\Public\Set-TeamViewerUser.ps1"
 
-    @(Get-ChildItem -Path "$PSScriptRoot\..\..\Cmdlets\Private\*.ps1") | `
-        ForEach-Object { . $_.FullName }
+    @(Get-ChildItem -Path "$PSScriptRoot\..\..\Cmdlets\Private\*.ps1") | ForEach-Object { . $_.FullName }
 
     $testApiToken = [securestring]@{}
     $null = $testApiToken
@@ -15,36 +14,26 @@ BeforeAll {
         # We do this only for testing
         [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
         param()
-        Process { $_ | ConvertTo-SecureString -AsPlainText -Force }
+        Process {
+            $_ | ConvertTo-SecureString -AsPlainText -Force
+        }
     }
 }
 
 Describe 'Set-TeamViewerUser' {
 
     It 'Should call the correct API endpoint' {
-        Set-TeamViewerUser `
-            -ApiToken $testApiToken `
-            -User 'u1234' `
-            -Name 'Updated User Name'
+        Set-TeamViewerUser -ApiToken $testApiToken -User 'u1234' -Name 'Updated User Name'
 
         Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
-            $ApiToken -eq $testApiToken -And `
-                $Uri -eq '//unit.test/users/u1234' -And `
-                $Method -eq 'Put' }
+            $ApiToken -eq $testApiToken -And $Uri -eq '//unit.test/users/u1234' -And $Method -eq 'Put' }
     }
 
     It 'Should change user properties' {
         $testPassword = 'Test1234' | ConvertTo-TestPassword
         $testSsoCustomerId = 'SsoTest' | ConvertTo-TestPassword
-        Set-TeamViewerUser `
-            -ApiToken $testApiToken `
-            -User 'u1234' `
-            -Name 'Updated User Name' `
-            -Email 'foo@bar.com' `
-            -Password $testPassword `
-            -SsoCustomerIdentifier $testSsoCustomerId `
-            -Permissions 'ManageAdmins', 'ManageUsers' `
-            -Active $false
+
+        Set-TeamViewerUser -ApiToken $testApiToken -User 'u1234' -Name 'Updated User Name' -Email 'foo@bar.com' -Password $testPassword -SsoCustomerIdentifier $testSsoCustomerId -Active $false
 
         $mockArgs.Body | Should -Not -BeNullOrEmpty
         $body = [System.Text.Encoding]::UTF8.GetString($mockArgs.Body) | ConvertFrom-Json
@@ -52,20 +41,15 @@ Describe 'Set-TeamViewerUser' {
         $body.email | Should -Be 'foo@bar.com'
         $body.password | Should -Be 'Test1234'
         $body.sso_customer_id | Should -Be 'SsoTest'
-        $body.permissions | Should -Be 'ManageAdmins,ManageUsers'
         $body.active | Should -BeFalse
     }
 
     It 'Should accept user properties as hashtable' {
-        Set-TeamViewerUser `
-            -ApiToken $testApiToken `
-            -User 'u1234' `
-            -Property @{
+        Set-TeamViewerUser -ApiToken $testApiToken -User 'u1234' -Property @{
             name            = 'Updated User Name'
             email           = 'foo@bar.com'
             password        = 'Test1234'
             sso_customer_id = 'SsoTest'
-            permissions     = 'ManageAdmins,ManageUsers'
             active          = $false
         }
 
@@ -75,16 +59,10 @@ Describe 'Set-TeamViewerUser' {
         $body.email | Should -Be 'foo@bar.com'
         $body.password | Should -Be 'Test1234'
         $body.sso_customer_id | Should -Be 'SsoTest'
-        $body.permissions | Should -Be 'ManageAdmins,ManageUsers'
         $body.active | Should -BeFalse
     }
 
     It 'Should throw if hashtable does not contain any valid change' {
-        { Set-TeamViewerUser `
-                -ApiToken $testApiToken `
-                -User 'u1234' `
-                -Property @{
-                foo = 'bar'
-            } } | Should -Throw
+        { Set-TeamViewerUser -ApiToken $testApiToken -User 'u1234' -Property @{ foo = 'bar' } } | Should -Throw
     }
 }


### PR DESCRIPTION
Remove old / former company permissions from user (Get-TeamViewerUser, New-TeamViewerUser, Set-TeamViewerUser), as user roles should be used.

- Removes parameters
- Updates tests
- Updates change log
- Updates documentation