### PR TITLE
Fix documentation for Get-TeamViewerCompanyManagedDevice Cmdlet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 2.1.1 (2025-02-05)
+
+### Fixed
+
+- Fixed documentation for Api parameter of the Get-TeamViewerCompanyManagedDevice Cmdlet. The targeted endpoint requires 'company admin' and 'Device Groups: read operations' permissions
+
 ## 2.1.0 (2024-11-15)
 
 ### Added
@@ -9,6 +15,7 @@
 ## 2.0.2 (2024-11-14)
 
 ### Added
+
 - Add-TeamViewerSsoInclusion command to add SSO Inclusion list items.
 
 ## 2.0.0 (2023-11-22)

--- a/Docs/Help/Get-TeamViewerCompanyManagedDevice.md
+++ b/Docs/Help/Get-TeamViewerCompanyManagedDevice.md
@@ -9,7 +9,7 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
-Retrieves TeamViewer company-managed devices. Requires an API Token with company admin permissions.
+Retrieves TeamViewer company-managed devices. Requires an API Token with 'company admin' and 'Device Groups: read operations' permissions.
 
 ## SYNTAX
 
@@ -38,7 +38,7 @@ List all company-managed devices of this company.
 
 ### -ApiToken
 
-The TeamViewer API access token. Needs to have company admin permissions to successfully retrieve the devices.
+The TeamViewer API access token. Needs to have 'company admin' and 'Device Groups: read operations' permissions to successfully retrieve the devices.
 
 ```yaml
 Type: SecureString


### PR DESCRIPTION
The targeted endpoint requires Device Groups: read operations permissions as well as company admin