### PR TITLE
TEAM-64227 Extend with move device to group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 2.2.0 (2025-03-11)
+
+### Added
+
+- Adds `Move-TeamViewerManagedDevice` to move a specific device from one managed group to another.
+
 ## 2.1.1 (2025-02-05)
 
 ### Fixed

--- a/Cmdlets/Public/Move-TeamViewerManagedDevice.ps1
+++ b/Cmdlets/Public/Move-TeamViewerManagedDevice.ps1
@@ -1,0 +1,47 @@
+function Move-TeamViewerManagedDevice {
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param(
+        [Parameter(Mandatory = $true)]
+        [securestring]
+        $ApiToken,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateScript( { $_ | Resolve-TeamViewerManagedDeviceId } )]
+        [Alias("DeviceId")]
+        [object]
+        $Device,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateScript( { $_ | Resolve-TeamViewerManagedGroupId } )]
+        [Alias("Source GroupId")]
+        [object]
+        $SourceGroup,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateScript( { $_ | Resolve-TeamViewerManagedGroupId } )]
+        [Alias("Target GroupId")]
+        [object]
+        $TargetGroup
+    )
+
+    $deviceId = $Device | Resolve-TeamViewerManagedDeviceId
+    $sourceGroupId = $SourceGroup | Resolve-TeamViewerManagedGroupId
+    $targetGroupId = $TargetGroup | Resolve-TeamViewerManagedGroupId
+    $resourceUri = "$(Get-TeamViewerApiUri)/managed/devices/$deviceId/groups"
+
+    $body = @{
+        AddedChainIds = @($targetGroupId)
+        RemovedChainIds = @($sourceGroupId)
+    }
+
+    if ($PSCmdlet.ShouldProcess($deviceId, "Move a device from one group to another")) {
+        Invoke-TeamViewerRestMethod `
+            -ApiToken $ApiToken `
+            -Uri $resourceUri `
+            -Method Put `
+            -ContentType "application/json; charset=utf-8" `
+            -Body ([System.Text.Encoding]::UTF8.GetBytes(($body | ConvertTo-Json))) `
+            -WriteErrorTo $PSCmdlet | `
+            Out-Null
+    }
+}

--- a/Docs/Help/Move-TeamViewerManagedDevice.md
+++ b/Docs/Help/Move-TeamViewerManagedDevice.md
@@ -1,0 +1,155 @@
+---
+external help file: TeamViewerPS-help.xml
+Module Name: TeamViewerPS
+online version: https://github.com/teamviewer/TeamViewerPS/blob/main/Docs/Help/Move-TeamViewerManagedDevice.md
+schema: 2.0.0
+---
+
+# Move-TeamViewerManagedDevice
+
+## SYNOPSIS
+
+Move a managed device from one managed group to another.
+
+## SYNTAX
+
+```powershell
+Move-TeamViewerManagedDevice [-ApiToken] <SecureString> [-Device] <Guid> [-SourceGroup] <Guid> [-TargetGroup] <Guid> [-WhatIf]
+ [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+Moves an existing managed device from one managed group to another.
+This will remove the device from the source group, and add the device to the target group.
+Offline devices will apply this change when coming online again.
+
+## EXAMPLES
+
+### Example
+
+```powershell
+PS /> Move-TeamViewerManagedDevice -Device 'c0cb303a-8a85-4e54-b657-a4757c791aef' -SourceGroup '9fd16af0-c224-4242-998e-a7138b038dbb' -TargetGroup '6084ffb1-c2d7-45e8-b6ab-5322ff761a30'
+```
+
+Moves the managed device with the given device ID from the managed group with the
+given group ID to another managed group with the given group ID.
+
+## PARAMETERS
+
+### -ApiToken
+
+The TeamViewer API access token.
+
+```yaml
+Type: SecureString
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Device
+
+A string representing the management ID of the device.
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases: DeviceId
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SourceGroup
+
+A string representing the group ID of the source group.
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases: GroupId
+
+Required: True
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TargetGroup
+
+A string representing the group ID of the target group.
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases: GroupId
+
+Required: True
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### None
+
+## NOTES
+
+## RELATED LINKS
+
+[Get-TeamViewerManagedDevice](Get-TeamViewerManagedDevice.md)
+
+[Get-TeamViewerManagedGroup](Get-TeamViewerManagedDevice.md)

--- a/Tests/Public/Move-TeamViewerManagedDevice.Tests.ps1
+++ b/Tests/Public/Move-TeamViewerManagedDevice.Tests.ps1
@@ -1,0 +1,45 @@
+BeforeAll {
+    . "$PSScriptRoot\..\..\Cmdlets\Public\Move-TeamViewerManagedDevice.ps1"
+
+    @(Get-ChildItem -Path "$PSScriptRoot\..\..\Cmdlets\Private\*.ps1") | `
+        ForEach-Object { . $_.FullName }
+
+    $testApiToken = [securestring]@{}
+    $null = $testApiToken
+    $testDeviceId = '9e5617cb-2b20-4da2-bca4-c1bda85b29ab'
+    $null = $testDeviceId
+    $testSourceGroupId = 'c37e72b8-b78d-467f-923c-6083c13cf82f'
+    $null = $testSourceGroupId
+    $testTargetGroupId = '5aa6c65b-4a24-465b-90da-197e5e883ac6'
+    $null = $testTargetGroupId
+
+    Mock Get-TeamViewerApiUri { '//unit.test' }
+    $mockArgs = @{}
+    Mock Invoke-TeamViewerRestMethod { $mockArgs.Body = $Body }
+}
+
+Describe 'Move-TeamViewerManagedDevice' {
+    It 'Should call the correct API endpoint to move a managed device from one group to another' {
+        Move-TeamViewerManagedDevice `
+            -ApiToken $testApiToken `
+            -Device $testDeviceId `
+            -SourceGroup $testSourceGroupId `
+            -TargetGroup $testTargetGroupId
+        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+            $ApiToken -eq $testApiToken -And `
+                $Uri -eq "//unit.test/managed/devices/$testDeviceId/groups" -And `
+                $Method -eq 'Put' }
+    }
+
+    It 'Should move the device from one group to another' {
+        Move-TeamViewerManagedDevice `
+            -ApiToken $testApiToken `
+            -Device $testDeviceId `
+            -SourceGroup $testSourceGroupId `
+            -TargetGroup $testTargetGroupId
+        $mockArgs.Body | Should -Not -BeNullOrEmpty
+        $body = [System.Text.Encoding]::UTF8.GetString($mockArgs.Body) | ConvertFrom-Json
+        $body.AddedChainIds | Should -Be $testTargetGroupId
+        $body.RemovedChainIds | Should -Be $testSourceGroupId
+    }
+}


### PR DESCRIPTION
Add a new PowerShell cmd-let to enable moving a managed device from one managed group to another.