### PR TITLE
Revert changes for PowerShell 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,7 @@
 # Change Log
 
 
-## 2.5.1 (2026-02-12)
-
-### Fixed
-
-- When the WebAPIUri was changed, we encountered issues in Windows PowerShell 5.1.
-After some investigation, it turned out that the TLS for the Invoke-WebRequest should not be changed from the SystemDefault value. It is recommended to use PowerShell 7 or later instead.
+## 2.5.1 (not released yet)
 
 ### Updated
 

--- a/Cmdlets/Private/Invoke-TeamViewerRestMethod.ps1
+++ b/Cmdlets/Private/Invoke-TeamViewerRestMethod.ps1
@@ -48,11 +48,8 @@ function Invoke-TeamViewerRestMethod {
     $PSBoundParameters.Remove('ApiToken') | Out-Null
     $PSBoundParameters.Remove('WriteErrorTo') | Out-Null
 
-    if ($PSVersionTable.PSVersion.Major -ge 6) {
-        $currentTlsSettings = [Net.ServicePointManager]::SecurityProtocol
-        # This had to be removed for Windows PowerShell 5.1 as it caused issue when Invoke-WebRequest was called
-        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    }
+    $currentTlsSettings = [Net.ServicePointManager]::SecurityProtocol
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
     $currentProgressPreference = $ProgressPreference
     $ProgressPreference = 'SilentlyContinue'
@@ -82,9 +79,7 @@ function Invoke-TeamViewerRestMethod {
         }
     }
     finally {
-        if ($PSVersionTable.PSVersion.Major -ge 6) {
-            [Net.ServicePointManager]::SecurityProtocol = $currentTlsSettings
-            $ProgressPreference = $currentProgressPreference
-        }
+        [Net.ServicePointManager]::SecurityProtocol = $currentTlsSettings
+        $ProgressPreference = $currentProgressPreference
     }
 }


### PR DESCRIPTION
A configuration issue was the root cause for Windows PowerShell 5 being unable to communicate correclty. Interestingly PowerShell 7 just ignored the request for TLS 1.2 and did something else. It still worked that way.