### PR TITLE
Add PolicyId output to Get-TeamViewerGroup function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Updated
 
+- Updates `Get-TeamViewerGroup` to list the assigned PolicyID of a defined group
 - Updates `Get-TeamViewerRole` to list all the possible permissions.
 - Updates `Set-TeamViewerManagedDevice`  with additional description endpoint.
 - Updates all tests to support the changed assertion syntax for Pester 6.0.0 or later.

--- a/Cmdlets/Private/ConvertTo-TeamViewerGroup.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerGroup.ps1
@@ -9,6 +9,7 @@ function ConvertTo-TeamViewerGroup {
             Id          = $InputObject.id
             Name        = $InputObject.name
             Permissions = $InputObject.permissions
+            PolicyId    = $InputObject.policy_id
             SharedWith  = @($InputObject.shared_with | ConvertTo-TeamViewerGroupShare)
         }
         if ($InputObject.owner) {

--- a/Tests/Public/Get-TeamViewerGroup.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerGroup.Tests.ps1
@@ -10,11 +10,14 @@ BeforeAll {
     Mock Get-TeamViewerApiUri { '//unit.test' }
     Mock Invoke-TeamViewerRestMethod { @{
             groups = @(
-                @{ id = 'g1234'; name = 'test group 1' },
-                @{ id = 'g4567'; name = 'test group 2' },
-                @{ id = 'g8901'; name = 'test group 3' }
+                @{ id = 'g1234'; name = 'test group 1'; policy_id = 'p1234' },
+                @{ id = 'g4567'; name = 'test group 2'; policy_id = 'p4567' },
+                @{ id = 'g8901'; name = 'test group 3'; policy_id = 'p8901' }
             )
         } }
+    Mock Invoke-TeamViewerRestMethod { @{ id = 'g1234'; name = 'test group 1'; policy_id = 'p1234' } } -ParameterFilter {
+        $Uri -eq '//unit.test/groups/g1234'
+    }
 }
 
 Describe 'Get-TeamViewerGroup' {
@@ -29,7 +32,7 @@ Describe 'Get-TeamViewerGroup' {
     }
 
     It 'Should call the correct API endpoint for single group' {
-        Get-TeamViewerGroup -ApiToken $testApiToken -Group 'g1234'
+        Get-TeamViewerGroup -ApiToken $testApiToken -Id 'g1234'
 
         Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
@@ -61,5 +64,15 @@ Describe 'Get-TeamViewerGroup' {
         Get-TeamViewerGroup -ApiToken $testApiToken -Name 'TestName'
         Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $Body -And $Body['name'] -eq 'TestName' }
+    }
+
+    It 'Should include PolicyId when getting single group' {
+        $result = Get-TeamViewerGroup -ApiToken $testApiToken -Id 'g1234'
+        $result.PolicyId | Should -Be 'p1234'
+    }
+
+    It 'Should include PolicyId when filtering groups' {
+        $result = Get-TeamViewerGroup -ApiToken $testApiToken
+        $result[0].PolicyId | Should -Be 'p1234'
     }
 }


### PR DESCRIPTION
### Summary
This PR adds the `PolicyId` field to the output of the `Get-TeamViewerGroup` function. This enhancement enables retreival of the PolicyID, assigned to a group via the `Get-TeamViewerGroup -Id <groupID>` cmdlet.

### Changes
- Added `PolicyId` field to `Get-TeamViewerGroup` cmdlet output
- Updated `ConvertTo-TeamViewerGroup` conversion function to support the new field
- Updated all related tests to accommodate the new field

### Motivation & Context
Being able to set an Policy to a group, I thought, "Why can't I retrieve it via the PowerShell module?" In a script that I had built, I had to use Invoke-RestMethod in the middle of the script, which is a bit of a maintenance pain. So I updated the module to make this output available too.

---

### Checklist

- [x] Tests have been added/updated and all tests pass
- [x] Changes have been tested locally
- [x] No breaking changes to existing functionality
