### PR TITLE
Tests update for Pester 6.0.0+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
               shell: pwsh
               run: |
                   $ProgressPreference = 'SilentlyContinue'
-                  Install-Module -Name Pester -SkipPublisherCheck -Scope CurrentUser -MinimumVersion 5.1.1 -Force -Verbose
+                  Install-Module -Name Pester -SkipPublisherCheck -Scope CurrentUser -MinimumVersion 6.0.0 -Force -Verbose
                   Invoke-Pester -Path $env:GITHUB_WORKSPACE -Output Detailed -CI
             # Build package
             - name: Package Build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,30 +1,31 @@
 # Change Log
 
 
-## 2.5.1 (not released yet)
+## 2.5.2 (not released yet)
 
 ### Updated
 
-- Updates `Get-TeamViewerRole` to list all the possible permissions
-- Updates `Set-TeamViewerManagedDevice`  with additional description endpoint
+- Updates `Get-TeamViewerRole` to list all the possible permissions.
+- Updates `Set-TeamViewerManagedDevice`  with additional description endpoint.
+- Updates all tests to support the changed assertion syntax for Pester 6.0.0 or later.
 
 ### Added
 
-- Adds `Get-TeamViewerInstallationType` that returns the TV installation type (MSI, exe or Unknown) from locally installed TV client
-- Adds `Get-TeamViewerRoleByUser` that returns the assigned role ids of the user
-- Adds `Get-TeamViewerEffectivePermission` that lists all effective permissions in a TeamViewer company
-- Adds new endpoint ID for function `Get-TeamViewerSsoDomain`
+- Adds `Get-TeamViewerInstallationType` that returns the TV installation type (MSI, exe or Unknown) from locally installed TV client.
+- Adds `Get-TeamViewerRoleByUser` that returns the assigned role ids of the user.
+- Adds `Get-TeamViewerEffectivePermission` that lists all effective permissions in a TeamViewer company.
+- Adds new endpoint ID for function `Get-TeamViewerSsoDomain`.
 
 
 ## 2.4.0 (2025-06-19)
 
 ### Added
 
-- Adds `Remove-TeamViewerUserTFA` to remove two-factor authentication from an account
+- Adds `Remove-TeamViewerUserTFA` to remove two-factor authentication from an account.
 
 ### Updated
 
-- Updates `Get-TeamViewerUser`, `Set-TeamViewerUser` and `New-TeamViewerUser` to reflect updated user attributes. This involves the addition of several attributes, as well as the removal of the deprecated Permissions attribute
+- Updates `Get-TeamViewerUser`, `Set-TeamViewerUser` and `New-TeamViewerUser` to reflect updated user attributes. This involves the addition of several attributes, as well as the removal of the deprecated Permissions attribute.
 
 
 ## 2.3.0 (2025-05-12)

--- a/Cmdlets/TeamViewerPS.psd1
+++ b/Cmdlets/TeamViewerPS.psd1
@@ -3,7 +3,7 @@
     RootModule        = 'TeamViewerPS.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '2.5.1'
+    ModuleVersion     = '2.5.2'
 
     # Supported PSEditions.
     # CompatiblePSEditions = @()

--- a/Tests/Public/Add-TeamViewerAssignment.Tests.ps1
+++ b/Tests/Public/Add-TeamViewerAssignment.Tests.ps1
@@ -26,7 +26,7 @@ Describe 'Add-TeamViewerAssignment' {
 
         It 'Should set the location to the installation directory' {
             Add-TeamViewerAssignment -AssignmentId '123' -DeviceAlias 'TestAlias' -Retries 3
-            Assert-MockCalled Set-Location -Scope It -Times 1 -ParameterFilter {
+            Should -Invoke Set-Location -Scope It -Times 1 -ParameterFilter {
                 $Path -eq 'testPath'
             }
         }
@@ -34,31 +34,31 @@ Describe 'Add-TeamViewerAssignment' {
         It 'Should call TeamViewer.exe assignment with device alias and retries' {
             Mock Start-Process -ParameterFilter { $_.FilePath -eq 'TeamViewer.exe' -and $_.ArgumentList -eq 'assignment --id 123 --device-alias=TestAlias --retries=3' }
             Add-TeamViewerAssignment -AssignmentId '123' -DeviceAlias 'TestAlias' -Retries 3
-            Assert-MockCalled Start-Process -Scope It -Times 1
+            Should -Invoke Start-Process -Scope It -Times 1
         }
 
         It 'Should call TeamViewer.exe assignment with device alias' {
             Mock Start-Process -ParameterFilter { $_.FilePath -eq 'TeamViewer.exe' -and $_.ArgumentList -eq 'assignment --id 123 --device-alias=TestAlias' }
             Add-TeamViewerAssignment -AssignmentId '123' -DeviceAlias 'TestAlias'
-            Assert-MockCalled Start-Process -Scope It -Times 1
+            Should -Invoke Start-Process -Scope It -Times 1
         }
 
         It 'Should call TeamViewer.exe assignment with retries' {
             Mock Start-Process -ParameterFilter { $_.FilePath -eq 'TeamViewer.exe' -and $_.ArgumentList -eq 'assignment --id 123 --retries=3' }
             Add-TeamViewerAssignment -AssignmentId '123' -Retries 3
-            Assert-MockCalled Start-Process -Scope It -Times 1
+            Should -Invoke Start-Process -Scope It -Times 1
         }
 
         It 'Should call TeamViewer.exe assignment without device alias or retries' {
             Mock Start-Process -ParameterFilter { $_.FilePath -eq 'TeamViewer.exe' -and $_.ArgumentList -eq 'assignment --id 123' }
             Add-TeamViewerAssignment -AssignmentId '123'
-            Assert-MockCalled Start-Process -Scope It -Times 1
+            Should -Invoke Start-Process -Scope It -Times 1
         }
 
         It 'Should restore the current directory after calling cmd.exe' {
             $currentDirectory = Get-Location
             Add-TeamViewerAssignment -AssignmentId '123' -DeviceAlias 'TestAlias'
-            Assert-MockCalled Set-Location -Scope It -Times 1 -ParameterFilter {
+            Should -Invoke Set-Location -Scope It -Times 1 -ParameterFilter {
                 $Path -eq $currentDirectory
             }
         }

--- a/Tests/Public/Add-TeamViewerCustomization.Tests.ps1
+++ b/Tests/Public/Add-TeamViewerCustomization.Tests.ps1
@@ -24,13 +24,13 @@ Describe 'Add-TeamViewerCustomization' {
         It 'Should call TeamViewer.exe customize with the provided Id' {
             Mock Start-Process -ParameterFilter { $_.FilePath -eq 'TeamViewer.exe' -and $_.ArgumentList -eq 'customize --id 123"' }
             Add-TeamViewerCustomization -Id '123'
-            Assert-MockCalled Start-Process -Scope It -Times 1
+            Should -Invoke Start-Process -Scope It -Times 1
         }
 
         It 'Should resolve the customization error code' {
             Mock Resolve-CustomizationErrorCode {}
             Add-TeamViewerCustomization -Id '123'
-            Assert-MockCalled Resolve-CustomizationErrorCode -Scope It -Times 1
+            Should -Invoke Resolve-CustomizationErrorCode -Scope It -Times 1
         }
     }
 
@@ -51,13 +51,13 @@ Describe 'Add-TeamViewerCustomization' {
         It 'Should call TeamViewer.exe customize with the provided Path' {
             Mock Start-Process -ParameterFilter { $_.FilePath -eq 'TeamViewer.exe' -and $_.ArgumentList -eq 'customize --path C:\TeamViewer.zip"' }
             Add-TeamViewerCustomization -Path 'C:\TeamViewer.zip'
-            Assert-MockCalled Start-Process -Scope It -Times 1
+            Should -Invoke Start-Process -Scope It -Times 1
         }
 
         It 'Should resolve the customization error code' {
             Mock Resolve-CustomizationErrorCode {}
             Add-TeamViewerCustomization -Path 'C:\TeamViewer.zip'
-            Assert-MockCalled Resolve-CustomizationErrorCode -Scope It -Times 1
+            Should -Invoke Resolve-CustomizationErrorCode -Scope It -Times 1
         }
     }
 
@@ -72,8 +72,8 @@ Describe 'Add-TeamViewerCustomization' {
         It 'Should write an error message' {
             Mock Write-Error -ParameterFilter { $_ -eq 'TeamViewer is not installed' }
             Add-TeamViewerCustomization -Id '123'
-            Assert-MockCalled Start-Process -Scope It -Times 0
-            Assert-MockCalled Write-Error -Scope It -Times 1
+            Should -Invoke Start-Process -Scope It -Times 0
+            Should -Invoke Write-Error -Scope It -Times 1
         }
     }
 }

--- a/Tests/Public/Add-TeamViewerManagedDevice.Tests.ps1
+++ b/Tests/Public/Add-TeamViewerManagedDevice.Tests.ps1
@@ -22,7 +22,7 @@ Describe 'Add-TeamViewerManagedDevice' {
             -ApiToken $testApiToken `
             -GroupId $testGroupId `
             -DeviceId $testDeviceId
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq "//unit.test/managed/groups/$testGroupId/devices" -And `
                 $Method -eq 'Post' }
@@ -44,7 +44,7 @@ Describe 'Add-TeamViewerManagedDevice' {
             -ApiToken $testApiToken `
             -Group $groupObj `
             -DeviceId $testDeviceId
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq "//unit.test/managed/groups/$testGroupId/devices" -And `
                 $Method -eq 'Post' }

--- a/Tests/Public/Add-TeamViewerManager.Tests.ps1
+++ b/Tests/Public/Add-TeamViewerManager.Tests.ps1
@@ -27,7 +27,7 @@ Describe 'Add-TeamViewerManager' {
                 -ApiToken $testApiToken `
                 -GroupId $testGroupId `
                 -AccountId $testAccountId
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
                 $ApiToken -eq $testApiToken -And `
                     $Uri -eq "//unit.test/managed/groups/$testGroupId/managers" -And `
                     $Method -eq 'Post' }
@@ -53,7 +53,7 @@ Describe 'Add-TeamViewerManager' {
                 -ApiToken $testApiToken `
                 -Group $groupObj `
                 -AccountId $testAccountId
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
                 $ApiToken -eq $testApiToken -And `
                     $Uri -eq "//unit.test/managed/groups/$testGroupId/managers" -And `
                     $Method -eq 'Post' }
@@ -66,7 +66,7 @@ Describe 'Add-TeamViewerManager' {
                 -ApiToken $testApiToken `
                 -DeviceId $testDeviceId `
                 -AccountId $testAccountId
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
                 $ApiToken -eq $testApiToken -And `
                     $Uri -eq "//unit.test/managed/devices/$testDeviceId/managers" -And `
                     $Method -eq 'Post' }
@@ -92,7 +92,7 @@ Describe 'Add-TeamViewerManager' {
                 -ApiToken $testApiToken `
                 -Device $deviceObj `
                 -AccountId $testAccountId
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
                 $ApiToken -eq $testApiToken -And `
                     $Uri -eq "//unit.test/managed/devices/$testDeviceId/managers" -And `
                     $Method -eq 'Post' }

--- a/Tests/Public/Add-TeamViewerSsoExclusion.Tests.ps1
+++ b/Tests/Public/Add-TeamViewerSsoExclusion.Tests.ps1
@@ -20,7 +20,7 @@ Describe 'Add-TeamViewerSsoExclusion' {
             -ApiToken $testApiToken `
             -DomainId $testDomainId `
             -Email 'foo@example.test'
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq "//unit.test/ssoDomain/$testDomainId/exclusion" -And `
                 $Method -eq 'Post' }
@@ -53,7 +53,7 @@ Describe 'Add-TeamViewerSsoExclusion' {
             -ApiToken $testApiToken `
             -Domain $testDomain `
             -Email 'foo@example.test'
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq "//unit.test/ssoDomain/$testDomainId/exclusion" -And `
                 $Method -eq 'Post' }
@@ -65,7 +65,7 @@ Describe 'Add-TeamViewerSsoExclusion' {
         $testAddresses | Add-TeamViewerSsoExclusion `
             -ApiToken $testApiToken `
             -DomainId $testDomainId
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 3 -Scope It
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 3 -Scope It
         $mockArgs.Body | Should -Not -BeNullOrEmpty
         $body = [System.Text.Encoding]::UTF8.GetString($mockArgs.Body) | ConvertFrom-Json
         $body.emails | Should -HaveCount 50

--- a/Tests/Public/Add-TeamViewerSsoInclusion.Tests.ps1
+++ b/Tests/Public/Add-TeamViewerSsoInclusion.Tests.ps1
@@ -20,7 +20,7 @@ Describe 'Add-TeamViewerSsoInclusion' {
             -ApiToken $testApiToken `
             -DomainId $testDomainId `
             -Email 'foo@example.test'
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq "//unit.test/ssoDomain/$testDomainId/inclusion" -And `
                 $Method -eq 'Post' }
@@ -53,7 +53,7 @@ Describe 'Add-TeamViewerSsoInclusion' {
             -ApiToken $testApiToken `
             -Domain $testDomain `
             -Email 'foo@example.test'
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq "//unit.test/ssoDomain/$testDomainId/inclusion" -And `
                 $Method -eq 'Post' }
@@ -65,7 +65,7 @@ Describe 'Add-TeamViewerSsoInclusion' {
         $testAddresses | Add-TeamViewerSsoInclusion `
             -ApiToken $testApiToken `
             -DomainId $testDomainId
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 3 -Scope It
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 3 -Scope It
         $mockArgs.Body | Should -Not -BeNullOrEmpty
         $body = [System.Text.Encoding]::UTF8.GetString($mockArgs.Body) | ConvertFrom-Json
         $body.emails | Should -HaveCount 50

--- a/Tests/Public/Add-TeamViewerUserGroupMember.Tests.ps1
+++ b/Tests/Public/Add-TeamViewerUserGroupMember.Tests.ps1
@@ -24,7 +24,7 @@ Describe 'Add-TeamViewerUserGroupMember' {
             -ApiToken $testApiToken `
             -UserGroup $testUserGroupId `
             -Member $testMembers
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq "//unit.test/usergroups/$testUserGroupId/members" -And `
                 $Method -eq 'Post' }
@@ -36,7 +36,7 @@ Describe 'Add-TeamViewerUserGroupMember' {
             -ApiToken $testApiToken `
             -UserGroup $testUserGroup `
             -Member $testMembers
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq "//unit.test/usergroups/$testUserGroupId/members" -And `
                 $Method -eq 'Post' }

--- a/Tests/Public/Add-TeamViewerUserGroupToRole.Tests.ps1
+++ b/Tests/Public/Add-TeamViewerUserGroupToRole.Tests.ps1
@@ -21,7 +21,7 @@ BeforeAll {
 Describe 'Add-TeamViewerUserGroupToRole' {
     It 'Should call the correct API endpoint' {
         Add-TeamViewerUserGroupToRole -ApiToken $testApiToken -RoleId $testRoleId -UserGroup $testUserGroup
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/userroles/assign/usergroup' -And `
                 $Method -eq 'Post'

--- a/Tests/Public/Add-TeamViewerUserToRole.Tests.ps1
+++ b/Tests/Public/Add-TeamViewerUserToRole.Tests.ps1
@@ -24,7 +24,7 @@ Describe 'Add-TeamViewerUserToRole' {
     It 'Should call the correct API endpoint' {
         Add-TeamViewerUserToRole -ApiToken $testApiToken -RoleId $testRoleId -Accounts $testAccount
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/userroles/assign/account' -And `
                 $Method -eq 'Post'

--- a/Tests/Public/Connect-TeamViewerApi.Tests.ps1
+++ b/Tests/Public/Connect-TeamViewerApi.Tests.ps1
@@ -20,7 +20,7 @@ Describe 'Connect-TeamViewerApi' {
         Connect-TeamViewerApi -ApiToken $testApiToken
         $global:PSDefaultParameterValues["*-Teamviewer*:ApiToken"] | Should -Be $testApiToken
 
-        Assert-MockCalled Invoke-TeamViewerPing -Scope It -Times 1 -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerPing -Scope It -Times 1 -ParameterFilter {
             $ApiToken -eq $testApiToken
         }
     }

--- a/Tests/Public/Export-TeamViewerSystemInformation.Tests.ps1
+++ b/Tests/Public/Export-TeamViewerSystemInformation.Tests.ps1
@@ -33,8 +33,8 @@ Describe "Export-TeamViewerSystemInformation" {
             Mock -CommandName "Copy-Item" -MockWith {$null}
             Mock -CommandName "Compress-Archive" -MockWith { $CompressPath }
             Export-TeamViewerSystemInformation -TargetDirectory $TargetDirectory
-            Assert-MockCalled -CommandName "Join-Path" -Exactly -Times 1
-            Assert-MockCalled -CommandName "Compress-Archive" -Times 1
+            Should -Invoke -CommandName "Join-Path" -Exactly -Times 1
+            Should -Invoke -CommandName "Compress-Archive" -Times 1
         }
     }
 
@@ -47,7 +47,7 @@ Describe "Export-TeamViewerSystemInformation" {
         It "Should write an error message" {
             Mock -CommandName "Write-Error" -MockWith { $null }
             Export-TeamViewerSystemInformation
-            Assert-MockCalled -CommandName "Write-Error" -Exactly -Times 1
+            Should -Invoke -CommandName "Write-Error" -Exactly -Times 1
         }
     }
 }

--- a/Tests/Public/Get-TeamViewerAccount.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerAccount.Tests.ps1
@@ -23,7 +23,7 @@ BeforeAll {
 Describe 'Get-TeamViewerAccount' {
     It 'Should call the correct API endpoint' {
         Get-TeamViewerAccount -ApiToken $testApiToken
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq "//unit.test/account" -And `
                 $Method -eq 'Get' }

--- a/Tests/Public/Get-TeamViewerCompanyManagedDevice.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerCompanyManagedDevice.Tests.ps1
@@ -29,7 +29,7 @@ Describe 'Get-TeamViewerCompanyManagedDevice' {
             $base_test_path = '//unit.test'
             $desired_endpoint = 'managed/devices/company'
 
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
                 $ApiToken -eq $testApiToken -And `
                     $Uri -eq "$base_test_path/$desired_endpoint" -And `
                     $Method -eq 'Get' }
@@ -60,7 +60,7 @@ Describe 'Get-TeamViewerCompanyManagedDevice' {
             $result = Get-TeamViewerCompanyManagedDevice -ApiToken $testApiToken
             $result | Should -HaveCount 4
 
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 2 -Scope It
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 2 -Scope It
         }
     }
 }

--- a/Tests/Public/Get-TeamViewerConnectionReport.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerConnectionReport.Tests.ps1
@@ -38,7 +38,7 @@ BeforeAll {
 Describe 'Get-TeamViewerConnectionReport' {
     It 'Should call the correct API endpoint to list connection reports' {
         Get-TeamViewerConnectionReport -ApiToken $testApiToken
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/reports/connections' -And `
                 $Method -eq 'Get' }
@@ -99,7 +99,7 @@ Describe 'Get-TeamViewerConnectionReport' {
 
         $result = Get-TeamViewerConnectionReport -ApiToken $testApiToken
         $result | Should -HaveCount 3
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 3 -Scope It
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 3 -Scope It
     }
 
     Context 'Filtering' {
@@ -110,55 +110,55 @@ Describe 'Get-TeamViewerConnectionReport' {
 
         It 'Should allow to filter by username' {
             Get-TeamViewerConnectionReport -ApiToken $testApiToken -UserName 'test-user1'
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It
             $mockArgs.Body.username | Should -Be 'test-user1'
         }
 
         It 'Should allow to filter by userid' {
             Get-TeamViewerConnectionReport -ApiToken $testApiToken -UserId 'u1234'
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It
             $mockArgs.Body.userid | Should -Be 'u1234'
         }
 
         It 'Should allow to filter by groupid' {
             Get-TeamViewerConnectionReport -ApiToken $testApiToken -GroupId 'g1234'
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It
             $mockArgs.Body.groupid | Should -Be 'g1234'
         }
 
         It 'Should allow to filter by device name' {
             Get-TeamViewerConnectionReport -ApiToken $testApiToken -DeviceName 'test-device1'
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It
             $mockArgs.Body.devicename | Should -Be 'test-device1'
         }
 
         It 'Should allow to filter by deviceid' {
             Get-TeamViewerConnectionReport -ApiToken $testApiToken -DeviceId 111
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It
             $mockArgs.Body.deviceid | Should -Be '111'
         }
 
         It 'Should allow to filter by session code' {
             Get-TeamViewerConnectionReport -ApiToken $testApiToken -SessionCode 's112233'
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It
             $mockArgs.Body.session_code | Should -Be 's112233'
         }
 
         It 'Should allow to filter for entries with session code' {
             Get-TeamViewerConnectionReport -ApiToken $testApiToken -WithSessionCode
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It
             $mockArgs.Body.has_code | Should -Be $true
         }
 
         It 'Should allow to filter for entries without session code' {
             Get-TeamViewerConnectionReport -ApiToken $testApiToken -WithoutSessionCode
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It
             $mockArgs.Body.has_code | Should -Be $false
         }
 
         It 'Should allow to filter by support session type' {
             Get-TeamViewerConnectionReport -ApiToken $testApiToken -SupportSessionType 'RemoteSupportActiveSdk'
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It
             $mockArgs.Body.support_session_type | Should -Be 3
         }
     }

--- a/Tests/Public/Get-TeamViewerContact.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerContact.Tests.ps1
@@ -20,7 +20,7 @@ BeforeAll {
 Describe 'Get-TeamViewerContact' {
     It 'Should call the correct API endpoint to list contacts' {
         Get-TeamViewerContact -ApiToken $testApiToken
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/contacts' -And `
                 $Method -eq 'Get' }
@@ -28,7 +28,7 @@ Describe 'Get-TeamViewerContact' {
 
     It 'Should call the correct API endpoint for single contact' {
         Get-TeamViewerContact -ApiToken $testApiToken -Id 'c1234'
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/contacts/c1234' -And `
                 $Method -eq 'Get' }
@@ -42,13 +42,13 @@ Describe 'Get-TeamViewerContact' {
 
     It 'Should allow to filter by partial name' {
         Get-TeamViewerContact -ApiToken $testApiToken -Name 'TestName'
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $Body -And $Body['name'] -eq 'TestName' }
     }
 
     It 'Should allow to filter by online state' {
         Get-TeamViewerContact -ApiToken $testApiToken -FilterOnlineState 'Busy'
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $Body -And $Body['online_state'] -eq 'busy' }
     }
 }

--- a/Tests/Public/Get-TeamViewerCustomModuleId.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerCustomModuleId.Tests.ps1
@@ -36,7 +36,7 @@ Describe 'Get-TeamViewerCustomModuleId' {
         It 'Should write an error message' {
             Mock Write-Error -ParameterFilter { $_ -eq 'TeamViewer is not installed' }
             Get-TeamViewerCustomModuleId
-            Assert-MockCalled Write-Error -Scope It -Times 1
+            Should -Invoke Write-Error -Scope It -Times 1
         }
     }
 

--- a/Tests/Public/Get-TeamViewerDevice.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerDevice.Tests.ps1
@@ -20,7 +20,7 @@ BeforeAll {
 Describe 'Get-TeamViewerDevice' {
     It 'Should call the correct API endpoint to list devices' {
         Get-TeamViewerDevice -ApiToken $testApiToken
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/devices' -And `
                 $Method -eq 'Get' }
@@ -28,7 +28,7 @@ Describe 'Get-TeamViewerDevice' {
 
     It 'Should call the correct API endpoint for single device' {
         Get-TeamViewerDevice -ApiToken $testApiToken -Id 'd1234'
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/devices/d1234' -And `
                 $Method -eq 'Get' }
@@ -42,13 +42,13 @@ Describe 'Get-TeamViewerDevice' {
 
     It 'Should allow to filter by TeamViewer ID' {
         Get-TeamViewerDevice -ApiToken $testApiToken -TeamViewerId 123456789
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $Body -And $Body['remotecontrol_id'] -eq 'r123456789' }
     }
 
     It 'Should allow to filter by online state' {
         Get-TeamViewerDevice -ApiToken $testApiToken -FilterOnlineState 'Busy'
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $Body -And $Body['online_state'] -eq 'busy' }
     }
 }

--- a/Tests/Public/Get-TeamViewerEffectivePermission.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerEffectivePermission.Tests.ps1
@@ -24,7 +24,7 @@ Describe 'Get-TeamViewerEffectivePermission' {
     It 'Should call the correct API endpoint to list permission' {
         Get-TeamViewerEffectivePermission -ApiToken $testApiToken
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -and `
                 $Uri -eq '//unit.test/users/effectivepermissions' -and `
                 $Method -eq 'Get' }
@@ -50,7 +50,7 @@ Describe 'Get-TeamViewerEffectivePermission' {
         $result = Get-TeamViewerEffectivePermission -ApiToken $testApiToken
         $result | Should -BeOfType [PSCustomObject]
         $result.PSObject.Properties | Should -Be $null
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -and `
                 $Uri -eq '//unit.test/users/effectivepermissions' -and `
                 $Method -eq 'Get' }

--- a/Tests/Public/Get-TeamViewerEventLog.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerEventLog.Tests.ps1
@@ -26,7 +26,7 @@ Describe 'Get-TeamViewerEventLog' {
 
     It 'Should call the correct API endpoint to get audit-log events' {
         Get-TeamViewerEventLog -ApiToken $testApiToken
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -Eq '//unit.test/EventLogging' -And `
                 $Method -eq 'Post' }
@@ -74,7 +74,7 @@ Describe 'Get-TeamViewerEventLog' {
         $result = Get-TeamViewerEventLog -ApiToken $testApiToken
         $result | Should -HaveCount 9
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 2 -Scope It
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 2 -Scope It
     }
 
     It 'Should filter by event names' {

--- a/Tests/Public/Get-TeamViewerGroup.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerGroup.Tests.ps1
@@ -22,7 +22,7 @@ Describe 'Get-TeamViewerGroup' {
     It 'Should call the correct API endpoint to list groups' {
         Get-TeamViewerGroup -ApiToken $testApiToken
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/groups' -And `
                 $Method -eq 'Get' }
@@ -31,7 +31,7 @@ Describe 'Get-TeamViewerGroup' {
     It 'Should call the correct API endpoint for single group' {
         Get-TeamViewerGroup -ApiToken $testApiToken -Group 'g1234'
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/groups/g1234' -And `
                 $Method -eq 'Get' }
@@ -45,21 +45,21 @@ Describe 'Get-TeamViewerGroup' {
 
     It 'Should allow to filter for shared-groups' {
         Get-TeamViewerGroup -ApiToken $testApiToken -FilterShared OnlyShared
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $Body -And $Body['shared'] -eq $true }
 
         Get-TeamViewerGroup -ApiToken $testApiToken -FilterShared OnlyNotShared
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $Body -And $Body['shared'] -eq $false }
 
         Get-TeamViewerGroup -ApiToken $testApiToken
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $Body -And $Body['shared'] -eq $null }
     }
 
     It 'Should allow to filter by partial name' {
         Get-TeamViewerGroup -ApiToken $testApiToken -Name 'TestName'
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $Body -And $Body['name'] -eq 'TestName' }
     }
 }

--- a/Tests/Public/Get-TeamViewerId.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerId.Tests.ps1
@@ -17,7 +17,7 @@ Describe 'Get-TeamViewerId' {
 
         It 'Should return the TeamViewer ID from the Windows Registry' {
             Get-TeamViewerId | Should -Be 123456
-            Assert-MockCalled Get-ItemPropertyValue -Scope It -Times 1 -ParameterFilter {
+            Should -Invoke Get-ItemPropertyValue -Scope It -Times 1 -ParameterFilter {
                 $Path -Eq 'testRegistry' -And $Name -Eq 'ClientID'
             }
         }
@@ -32,7 +32,7 @@ Describe 'Get-TeamViewerId' {
 
         It 'Should return the TeamViewer ID from the global configuration' {
             Get-TeamViewerId | Should -Be 123456
-            Assert-MockCalled Get-TeamViewerLinuxGlobalConfig -Scope It -Times 1 -ParameterFilter {
+            Should -Invoke Get-TeamViewerLinuxGlobalConfig -Scope It -Times 1 -ParameterFilter {
                 $Name -Eq 'ClientID'
             }
         }
@@ -41,7 +41,7 @@ Describe 'Get-TeamViewerId' {
     It 'Should return nothing if TeamViewer if not installed' {
         Mock Test-TeamViewerInstallation { $false }
         Get-TeamViewerId | Should -BeNullOrEmpty
-        Assert-MockCalled Get-ItemPropertyValue -Scope It -Times 0
+        Should -Invoke Get-ItemPropertyValue -Scope It -Times 0
     }
 
     It 'Should return nothing on unsupported platforms' {

--- a/Tests/Public/Get-TeamViewerInstallationDirectory.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerInstallationDirectory.Tests.ps1
@@ -24,13 +24,13 @@ Describe 'Get-TeamViewerInstallationDirectory' {
         It 'Should check the registry path and return the installation directory' {
             $result = Get-TeamViewerInstallationDirectory
             $result | Should -Be 'testPath'
-            Assert-MockCalled Test-Path -Scope It -Times 1 -ParameterFilter {
+            Should -Invoke Test-Path -Scope It -Times 1 -ParameterFilter {
                 $Path -eq 'testRegistry'
             }
-            Assert-MockCalled Get-Item -Scope It -Times 1 -ParameterFilter {
+            Should -Invoke Get-Item -Scope It -Times 1 -ParameterFilter {
                 $Path -eq 'testRegistry'
             }
-            Assert-MockCalled Test-Path -Scope It -Times 1 -ParameterFilter {
+            Should -Invoke Test-Path -Scope It -Times 1 -ParameterFilter {
                 $Path -eq 'testPath/TeamViewer.exe'
             }
         }
@@ -51,7 +51,7 @@ Describe 'Get-TeamViewerInstallationDirectory' {
         It 'Should return the Linux installation directory' {
             $result = Get-TeamViewerInstallationDirectory
             $result | Should -Be '/opt/teamviewer/tv_bin/'
-            Assert-MockCalled Test-Path -Scope It -Times 1 -ParameterFilter {
+            Should -Invoke Test-Path -Scope It -Times 1 -ParameterFilter {
                 $Path -eq '/opt/teamviewer/tv_bin/TeamViewer'
             }
         }

--- a/Tests/Public/Get-TeamViewerInstallationType.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerInstallationType.Tests.ps1
@@ -7,27 +7,27 @@ BeforeAll {
 Describe 'Get-TeamViewerInstallationType' {
     Context 'MsiInstallation - both database and registry present' {
         BeforeAll {
-            Mock Get-CimInstance { 
-                [PSCustomObject]@{ Name = 'TeamViewer' } 
+            Mock Get-CimInstance {
+                [PSCustomObject]@{ Name = 'TeamViewer' }
             }
-            Mock Get-ItemProperty { 
-                [PSCustomObject]@{ MsiInstallation = 1 } 
+            Mock Get-ItemProperty {
+                [PSCustomObject]@{ MsiInstallation = 1 }
             }
         }
 
         It 'Should return MSI when MSI database and MsiInstallation registry value are both present' {
             $result = Get-TeamViewerInstallationType
             $result | Should -Be 'MSI'
-            Assert-MockCalled Get-CimInstance -Times 1
+            Should -Invoke Get-CimInstance -Times 1
         }
     }
 
     Context 'MSI database found but no registry value' {
         BeforeAll {
-            Mock Get-CimInstance { 
-                [PSCustomObject]@{ Name = 'TeamViewer' } 
+            Mock Get-CimInstance {
+                [PSCustomObject]@{ Name = 'TeamViewer' }
             }
-            Mock Get-ItemProperty { 
+            Mock Get-ItemProperty {
                 throw [System.Management.Automation.ItemNotFoundException]::new()
             }
         }
@@ -40,11 +40,11 @@ Describe 'Get-TeamViewerInstallationType' {
 
     Context 'Registry value found but no MSI database entry' {
         BeforeAll {
-            Mock Get-CimInstance { 
+            Mock Get-CimInstance {
                 throw [System.Management.Automation.ItemNotFoundException]::new()
             }
-            Mock Get-ItemProperty { 
-                [PSCustomObject]@{ MsiInstallation = 1 } 
+            Mock Get-ItemProperty {
+                [PSCustomObject]@{ MsiInstallation = 1 }
             }
         }
 
@@ -56,10 +56,10 @@ Describe 'Get-TeamViewerInstallationType' {
 
     Context 'exeInstallation with valid UninstallString' {
         BeforeAll {
-            Mock Get-CimInstance { 
+            Mock Get-CimInstance {
                 throw [System.Management.Automation.ItemNotFoundException]::new()
             }
-            Mock Get-ItemProperty { 
+            Mock Get-ItemProperty {
                 throw [System.Management.Automation.ItemNotFoundException]::new()
             } -ParameterFilter { $Name -eq 'MsiInstallation' }
             Mock Test-Path { $true }
@@ -71,7 +71,7 @@ Describe 'Get-TeamViewerInstallationType' {
                 $registryKey
             }
             Mock Get-ItemProperty {
-                [PSCustomObject]@{ 
+                [PSCustomObject]@{
                     UninstallString = '"C:\Program Files\TeamViewer\uninstall.exe" /S'
                 }
             } -ParameterFilter { $Name -eq 'UninstallString' }
@@ -85,10 +85,10 @@ Describe 'Get-TeamViewerInstallationType' {
 
     Context 'Broken exeInstallation with missing UninstallString file' {
         BeforeAll {
-            Mock Get-CimInstance { 
+            Mock Get-CimInstance {
                 throw [System.Management.Automation.ItemNotFoundException]::new()
             }
-            Mock Get-ItemProperty { 
+            Mock Get-ItemProperty {
                 throw [System.Management.Automation.ItemNotFoundException]::new()
             } -ParameterFilter { $Name -eq 'MsiInstallation' }
             Mock Get-ChildItem {
@@ -99,11 +99,11 @@ Describe 'Get-TeamViewerInstallationType' {
                 $registryKey
             }
             Mock Get-ItemProperty {
-                [PSCustomObject]@{ 
+                [PSCustomObject]@{
                     UninstallString = '"C:\Program Files\TeamViewer\uninstall.exe" /S'
                 }
             } -ParameterFilter { $Name -eq 'UninstallString' }
-            
+
             Mock Test-Path {
                 param($Path)
                 if ($Path -like '*:\Software\*' -or $Path -like '*:\HKEY_*') {
@@ -122,10 +122,10 @@ Describe 'Get-TeamViewerInstallationType' {
 
     Context 'TeamViewer not installed' {
         BeforeAll {
-            Mock Get-CimInstance { 
+            Mock Get-CimInstance {
                 throw [System.Management.Automation.ItemNotFoundException]::new()
             }
-            Mock Get-ItemProperty { 
+            Mock Get-ItemProperty {
                 throw [System.Management.Automation.ItemNotFoundException]::new()
             }
             Mock Get-ChildItem { }
@@ -140,8 +140,8 @@ Describe 'Get-TeamViewerInstallationType' {
 
     Context 'Check both 32-bit and 64-bit registry paths for MSI' {
         BeforeAll {
-            Mock Get-CimInstance { 
-                [PSCustomObject]@{ Name = 'TeamViewer' } 
+            Mock Get-CimInstance {
+                [PSCustomObject]@{ Name = 'TeamViewer' }
             }
             Mock Get-ItemProperty {
                 param($Path)
@@ -162,14 +162,14 @@ Describe 'Get-TeamViewerInstallationType' {
 
     Context 'Check both uninstall registry paths for exe' {
         BeforeAll {
-            Mock Get-CimInstance { 
+            Mock Get-CimInstance {
                 throw [System.Management.Automation.ItemNotFoundException]::new()
             }
-            Mock Get-ItemProperty { 
+            Mock Get-ItemProperty {
                 throw [System.Management.Automation.ItemNotFoundException]::new()
             } -ParameterFilter { $Name -eq 'MsiInstallation' }
             Mock Get-ItemProperty {
-                [PSCustomObject]@{ 
+                [PSCustomObject]@{
                     UninstallString = 'C:\Program Files (x86)\TeamViewer\uninstall.exe /quiet'
                 }
             } -ParameterFilter { $Name -eq 'UninstallString' }
@@ -191,11 +191,11 @@ Describe 'Get-TeamViewerInstallationType' {
 
     Context 'MSI installation with MSIInstallation value of 0' {
         BeforeAll {
-            Mock Get-CimInstance { 
+            Mock Get-CimInstance {
                 throw [System.Management.Automation.ItemNotFoundException]::new()
             }
-            Mock Get-ItemProperty { 
-                [PSCustomObject]@{ MsiInstallation = 0 } 
+            Mock Get-ItemProperty {
+                [PSCustomObject]@{ MsiInstallation = 0 }
             } -ParameterFilter { $Name -eq 'MsiInstallation' }
             Mock Get-ChildItem {
                 $registryKey = New-Object PSObject
@@ -205,7 +205,7 @@ Describe 'Get-TeamViewerInstallationType' {
                 $registryKey
             }
             Mock Get-ItemProperty {
-                [PSCustomObject]@{ 
+                [PSCustomObject]@{
                     UninstallString = 'C:\Program Files\TeamViewer\uninstall.exe'
                 }
             } -ParameterFilter { $Name -eq 'UninstallString' }

--- a/Tests/Public/Get-TeamViewerLogFilePath.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerLogFilePath.Tests.ps1
@@ -29,7 +29,7 @@ Describe 'Get-TeamViewerLogFilePath function' {
         It 'Should write an error message' {
             Mock -CommandName 'Write-Error' -MockWith { $null }
             Get-TeamViewerLogFilePath
-            Assert-MockCalled -CommandName 'Write-Error' -Exactly -Times 1
+            Should -Invoke -CommandName 'Write-Error' -Exactly -Times 1
         }
     }
 }

--- a/Tests/Public/Get-TeamViewerManagedDevice.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerManagedDevice.Tests.ps1
@@ -26,7 +26,7 @@ Describe 'Get-TeamViewerManagedDevice' {
         It 'Should call the correct API endpoint to list managed devices' {
             Get-TeamViewerManagedDevice -ApiToken $testApiToken
 
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
                 $ApiToken -eq $testApiToken -And `
                     $Uri -eq '//unit.test/managed/devices' -And `
                     $Method -eq 'Get' }
@@ -57,7 +57,7 @@ Describe 'Get-TeamViewerManagedDevice' {
             $result = Get-TeamViewerManagedDevice -ApiToken $testApiToken
             $result | Should -HaveCount 4
 
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 2 -Scope It
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 2 -Scope It
         }
     }
 
@@ -72,7 +72,7 @@ Describe 'Get-TeamViewerManagedDevice' {
         It 'Should call the correct API endpoint for single managed group' {
             Get-TeamViewerManagedDevice -ApiToken $testApiToken -Id 'ae222e9d-a665-4cea-85b7-d4a3a08a5e35'
 
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
                 $ApiToken -eq $testApiToken -And `
                     $Uri -eq '//unit.test/managed/devices/ae222e9d-a665-4cea-85b7-d4a3a08a5e35' -And `
                     $Method -eq 'Get' }
@@ -112,7 +112,7 @@ Describe 'Get-TeamViewerManagedDevice' {
 
         It 'Should call the correct API endpoint to list managed group devices' {
             Get-TeamViewerManagedDevice -ApiToken $testApiToken -GroupId $testGroupId
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
                 $ApiToken -eq $testApiToken -And `
                     $Uri -eq "//unit.test/managed/groups/$testGroupId/devices" -And `
                     $Method -eq 'Get' }
@@ -128,7 +128,7 @@ Describe 'Get-TeamViewerManagedDevice' {
         It 'Should handle group objects as input' {
             $testGroup = @{id = $testGroupId; name = 'test managed group' } | ConvertTo-TeamViewerManagedGroup
             Get-TeamViewerManagedDevice -ApiToken $testApiToken -Group $testGroup
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
                 $ApiToken -eq $testApiToken -And `
                     $Uri -eq "//unit.test/managed/groups/$testGroupId/devices" -And `
                     $Method -eq 'Get' }
@@ -170,12 +170,12 @@ Describe 'Get-TeamViewerManagedDevice' {
             $result = Get-TeamViewerManagedDevice -ApiToken $testApiToken -GroupId $testGroupId
             $result | Should -HaveCount 3
 
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 2 -Scope It
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 2 -Scope It
         }
 
         It 'Should call the correct API endpoint to list managed group pending devices' {
             Get-TeamViewerManagedDevice -ApiToken $testApiToken -GroupId $testGroupId -Pending
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
                 $ApiToken -eq $testApiToken -And `
                     $Uri -eq "//unit.test/managed/groups/$testGroupId/pending-devices" -And `
                     $Method -eq 'Get' }

--- a/Tests/Public/Get-TeamViewerManagedGroup.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerManagedGroup.Tests.ps1
@@ -27,7 +27,7 @@ Describe 'Get-TeamViewerManagedGroup' {
         It 'Should call the correct API endpoint to list managed groups' {
             Get-TeamViewerManagedGroup -ApiToken $testApiToken
 
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
                 $ApiToken -eq $testApiToken -And `
                     $Uri -eq '//unit.test/managed/groups' -And `
                     $Method -eq 'Get' }
@@ -58,7 +58,7 @@ Describe 'Get-TeamViewerManagedGroup' {
             $result = Get-TeamViewerManagedGroup -ApiToken $testApiToken
             $result | Should -HaveCount 4
 
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 2 -Scope It
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 2 -Scope It
         }
     }
 
@@ -73,7 +73,7 @@ Describe 'Get-TeamViewerManagedGroup' {
         It 'Should call the correct API endpoint for single managed group' {
             Get-TeamViewerManagedGroup -ApiToken $testApiToken -Group 'ae222e9d-a665-4cea-85b7-d4a3a08a5e35'
 
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
                 $ApiToken -eq $testApiToken -And `
                     $Uri -eq '//unit.test/managed/groups/ae222e9d-a665-4cea-85b7-d4a3a08a5e35' -And `
                     $Method -eq 'Get' }
@@ -102,7 +102,7 @@ Describe 'Get-TeamViewerManagedGroup' {
 
         It 'Should call the correct API endpoint to fetch the list of groups that the device is part of' {
             Get-TeamViewerManagedGroup -ApiToken $testApiToken -Device $testDeviceId
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
                 $ApiToken -eq $testApiToken -And `
                     $Uri -eq "//unit.test/managed/devices/$testDeviceId/groups" -And `
                     $Method -eq 'Get' }
@@ -119,7 +119,7 @@ Describe 'Get-TeamViewerManagedGroup' {
         It 'Should accept a ManagedDevice object as input' {
             $testDevice = @{ id = $testDeviceId; name = 'test device' } | ConvertTo-TeamViewerManagedDevice
             Get-TeamViewerManagedGroup -ApiToken $testApiToken -Device $testDevice
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
                 $ApiToken -eq $testApiToken -And `
                     $Uri -eq "//unit.test/managed/devices/$testDeviceId/groups" -And `
                     $Method -eq 'Get' }

--- a/Tests/Public/Get-TeamViewerManagementId.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerManagementId.Tests.ps1
@@ -31,19 +31,19 @@ Describe 'Get-TeamViewerManagementId' {
 
         It 'Should return the Management ID from the Windows Registry' {
             Get-TeamViewerManagementId | Should -Be $testManagementId
-            Assert-MockCalled Test-TeamViewerInstallation -Scope It -Times 1
-            Assert-MockCalled Get-OperatingSystem -Scope It -Times 1
-            Assert-MockCalled Get-TeamViewerRegKeyPath -Scope It -Times 1
-            Assert-MockCalled Test-Path -Scope It -Times 1 -ParameterFilter {
+            Should -Invoke Test-TeamViewerInstallation -Scope It -Times 1
+            Should -Invoke Get-OperatingSystem -Scope It -Times 1
+            Should -Invoke Get-TeamViewerRegKeyPath -Scope It -Times 1
+            Should -Invoke Test-Path -Scope It -Times 1 -ParameterFilter {
                 $LiteralPath -eq (Join-Path 'testRegistry' 'DeviceManagementV2')
             }
-            Assert-MockCalled Get-Item -Scope It -Times 1 -ParameterFilter {
+            Should -Invoke Get-Item -Scope It -Times 1 -ParameterFilter {
                 $Path -eq (Join-Path 'testRegistry' 'DeviceManagementV2')
             }
-            Assert-MockCalled Get-TestItemValue -Scope It -Times 1 -ParameterFilter {
+            Should -Invoke Get-TestItemValue -Scope It -Times 1 -ParameterFilter {
                 $obj -eq 'Unmanaged'
             }
-            Assert-MockCalled Get-TestItemValue -Scope It -Times 1 -ParameterFilter {
+            Should -Invoke Get-TestItemValue -Scope It -Times 1 -ParameterFilter {
                 $obj -eq 'ManagementId'
             }
         }
@@ -83,8 +83,8 @@ Describe 'Get-TeamViewerManagementId' {
 
         It 'Should return the Management ID from the global configuration' {
             Get-TeamViewerManagementId | Should -Be $testManagementId
-            Assert-MockCalled Test-TeamViewerInstallation -Scope It -Times 1
-            Assert-MockCalled Get-OperatingSystem -Scope It -Times 1
+            Should -Invoke Test-TeamViewerInstallation -Scope It -Times 1
+            Should -Invoke Get-OperatingSystem -Scope It -Times 1
         }
 
         It 'Should return nothing when TeamViewer is not installed' {

--- a/Tests/Public/Get-TeamViewerManager.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerManager.Tests.ps1
@@ -36,7 +36,7 @@ Describe 'Get-TeamViewerManager' {
     Context 'List Group Managers' {
         It 'Should call the correct API endpoint to list managed group managers' {
             Get-TeamViewerManager -ApiToken $testApiToken -GroupId $testGroupId
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
                 $ApiToken -eq $testApiToken -And `
                     $Uri -eq "//unit.test/managed/groups/$testGroupId/managers" -And `
                     $Method -eq 'Get' }
@@ -61,7 +61,7 @@ Describe 'Get-TeamViewerManager' {
     Context 'List Device Managers' {
         It 'Should call the correct API endpoint to list managed device managers' {
             Get-TeamViewerManager -ApiToken $testApiToken -DeviceId $testDeviceId
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
                 $ApiToken -eq $testApiToken -And `
                     $Uri -eq "//unit.test/managed/devices/$testDeviceId/managers" -And `
                     $Method -eq 'Get' }

--- a/Tests/Public/Get-TeamViewerPolicy.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerPolicy.Tests.ps1
@@ -26,7 +26,7 @@ Describe 'Get-TeamViewerPolicy' {
         It 'Should call the correct API endpoint to list policies' {
             Get-TeamViewerPolicy -ApiToken $testApiToken
 
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
                 $ApiToken -eq $testApiToken -And `
                     $Uri -eq '//unit.test/teamviewerpolicies' -And `
                     $Method -eq 'Get' }
@@ -51,7 +51,7 @@ Describe 'Get-TeamViewerPolicy' {
         It 'Should call the correct API endpoint for single policy' {
             Get-TeamViewerPolicy -ApiToken $testApiToken -Id 'ae222e9d-a665-4cea-85b7-d4a3a08a5e35'
 
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
                 $ApiToken -eq $testApiToken -And `
                     $Uri -eq '//unit.test/teamviewerpolicies/ae222e9d-a665-4cea-85b7-d4a3a08a5e35' -And `
                     $Method -eq 'Get' }

--- a/Tests/Public/Get-TeamViewerPredefinedRole.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerPredefinedRole.Tests.ps1
@@ -18,7 +18,7 @@ Describe 'Get-TeamViewerPredefinedRole' {
     It 'Should call the correct API endpoint to list PredefinedRole' {
         Get-TeamViewerPredefinedRole -ApiToken $testApiToken
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/userroles/predefined' -And `
                 $Method -eq 'Get' }

--- a/Tests/Public/Get-TeamViewerRole.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerRole.Tests.ps1
@@ -23,7 +23,7 @@ Describe 'Get-TeamViewerRole' {
     It 'Should call the correct API endpoint to list roles' {
         Get-TeamViewerRole -ApiToken $testApiToken
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/userroles' -And `
                 $Method -eq 'Get' }
@@ -56,7 +56,7 @@ Describe 'Get-TeamViewerRole' {
     It 'Should call the correct API endpoint for assigned users' {
         Get-TeamViewerRole -ApiToken $testApiToken
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/userroles' -And `
                 $Method -eq 'Get' }
@@ -64,7 +64,7 @@ Describe 'Get-TeamViewerRole' {
     It 'Should call the correct API endpoint to list permissions' {
         Get-TeamViewerRole -ApiToken $testApiToken -Permissions
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/userroles/permissions' -And `
                 $Method -eq 'Get' }

--- a/Tests/Public/Get-TeamViewerRoleByUser.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerRoleByUser.Tests.ps1
@@ -32,10 +32,10 @@ Describe 'Get-TeamViewerUserByRole' {
         It 'Should call the correct API endpoint' {
             Get-TeamViewerRoleByUser -ApiToken $testApiToken -UserId $testUserId
 
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
                 $ApiToken -eq $testApiToken -And `
                     $Uri -eq "//unit.test/users/$testUserId/userroles?paginationToken=Test1" -And `
-                    $Method -eq 'Get' 
+                    $Method -eq 'Get'
             }
         }
         It 'Should return assigned users' {

--- a/Tests/Public/Get-TeamViewerRoleByUserGroup.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerRoleByUserGroup.Tests.ps1
@@ -20,7 +20,7 @@ Describe 'Get-TeamViewerUserGroupByRole' {
         It 'Should call the correct API endpoint' {
             Get-TeamViewerRoleByUserGroup -ApiToken $testApiToken -GroupId $testGroupId
 
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
                 $ApiToken -eq $testApiToken -And `
                     $Uri -eq "//unit.test/usergroups/$testGroupId/userroles" -And `
                     $Method -eq 'Get'

--- a/Tests/Public/Get-TeamViewerService.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerService.Tests.ps1
@@ -23,7 +23,7 @@ Describe 'Get-TeamViewerService' {
         }
         It 'Should get the TeamViewer Windows service' {
             Get-TeamViewerService | Out-Null
-            Assert-MockCalled Get-Service -Scope It -Times 1 -ParameterFilter {
+            Should -Invoke Get-Service -Scope It -Times 1 -ParameterFilter {
                 $Name -eq 'UnitTestTeamViewer'
             }
         }
@@ -35,7 +35,7 @@ Describe 'Get-TeamViewerService' {
         }
         It 'Should get the TeamViewer daemon status' {
             Get-TeamViewerService | Out-Null
-            Assert-MockCalled Invoke-ExternalCommand -Scope It -Times 1 -ParameterFilter {
+            Should -Invoke Invoke-ExternalCommand -Scope It -Times 1 -ParameterFilter {
                 $Command -eq '/opt/teamviewer/tv_bin/script/teamviewer' -And
                 $CommandArgs[0] -eq 'daemon' -and $CommandArgs[1] -eq 'status'
             }

--- a/Tests/Public/Get-TeamViewerSsoDomain.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerSsoDomain.Tests.ps1
@@ -8,12 +8,12 @@ BeforeAll {
     $null = $testApiToken
 
     Mock Get-TeamViewerApiUri { '//unit.test' }
-    
+
 }
 
 Describe 'Get-TeamViewerSsoDomain' {
 
-    Context 'List' {  
+    Context 'List' {
        BeforeAll {
         Mock Invoke-TeamViewerRestMethod {
         @{
@@ -21,12 +21,12 @@ Describe 'Get-TeamViewerSsoDomain' {
                 @{ DomainId = '45e0d050-15e6-4fcb-91b2-ea4f20fe2085'; DomainName = 'domain1.test' },
                 @{ DomainId = 'b610124c-14b9-4b37-a2a4-a5ef678e16ed'; DomainName = 'domain2.test' }
             )
-        } } 
+        } }
     }
         It 'Should call the correct API endpoint' {
         Get-TeamViewerSsoDomain -ApiToken $testApiToken
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq "//unit.test/ssoDomain" -And `
                 $Method -eq 'Get' }
@@ -41,7 +41,7 @@ Describe 'Get-TeamViewerSsoDomain' {
 
     }
 
-   Context 'Single SsoDomain' {  
+   Context 'Single SsoDomain' {
         BeforeAll {
             Mock Invoke-TeamViewerRestMethod { @{
                     domains = @(
@@ -53,7 +53,7 @@ Describe 'Get-TeamViewerSsoDomain' {
         It 'Should call the correct API endpoint for single domain' {
             Get-TeamViewerSsoDomain -ApiToken $testApiToken -Id '45e0d050-15e6-4fcb-91b2-ea4f20fe2085'
 
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
                 $ApiToken -eq $testApiToken -And `
                     $Uri -eq '//unit.test/ssoDomain/45e0d050-15e6-4fcb-91b2-ea4f20fe2085' -And `
                     $Method -eq 'Get' }
@@ -63,7 +63,7 @@ Describe 'Get-TeamViewerSsoDomain' {
             $result = Get-TeamViewerSsoDomain -ApiToken $testApiToken -Id '45e0d050-15e6-4fcb-91b2-ea4f20fe2085'
             $result | Should -BeOfType PSObject
             $result.PSObject.TypeNames | Should -Contain 'TeamViewerPS.SsoDomain'
-        }    
+        }
 
    }
 

--- a/Tests/Public/Get-TeamViewerSsoExclusion.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerSsoExclusion.Tests.ps1
@@ -24,7 +24,7 @@ BeforeAll {
 Describe 'Get-TeamViewerSsoExclusion' {
     It 'Should call the correct API endpoint' {
         Get-TeamViewerSsoExclusion -ApiToken $testApiToken -DomainId $testDomainId
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq "//unit.test/ssoDomain/$testDomainId/exclusion" -And `
                 $Method -eq 'Get' }
@@ -60,14 +60,14 @@ Describe 'Get-TeamViewerSsoExclusion' {
         $result | Should -Contain 'test6@example.com'
         $result | Should -Contain 'test7@example.com'
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 2 -Scope It
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 2 -Scope It
     }
 
     It 'Should handle domain objects as input' {
         $testDomain = @{DomainId = $testDomainId; DomainName = 'test managed group' } | ConvertTo-TeamViewerSsoDomain
         $result = Get-TeamViewerSsoExclusion -ApiToken $testApiToken -Domain $testDomain
         $result | Should -HaveCount 3
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq "//unit.test/ssoDomain/$testDomainId/exclusion" -And `
                 $Method -eq 'Get' }

--- a/Tests/Public/Get-TeamViewerSsoInclusion.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerSsoInclusion.Tests.ps1
@@ -24,7 +24,7 @@ BeforeAll {
 Describe 'Get-TeamViewerSsoInclusion' {
     It 'Should call the correct API endpoint' {
         Get-TeamViewerSsoInclusion -ApiToken $testApiToken -DomainId $testDomainId
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq "//unit.test/ssoDomain/$testDomainId/inclusion" -And `
                 $Method -eq 'Get' }
@@ -60,14 +60,14 @@ Describe 'Get-TeamViewerSsoInclusion' {
         $result | Should -Contain 'test6@example.com'
         $result | Should -Contain 'test7@example.com'
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 2 -Scope It
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 2 -Scope It
     }
 
     It 'Should handle domain objects as input' {
         $testDomain = @{DomainId = $testDomainId; DomainName = 'test managed group' } | ConvertTo-TeamViewerSsoDomain
         $result = Get-TeamViewerSsoInclusion -ApiToken $testApiToken -Domain $testDomain
         $result | Should -HaveCount 3
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq "//unit.test/ssoDomain/$testDomainId/inclusion" -And `
                 $Method -eq 'Get' }
@@ -78,7 +78,7 @@ Describe 'Get-TeamViewerSsoInclusion' {
         $testDomain = @{DomainId = $testDomainId; DomainName = 'test managed group' } | ConvertTo-TeamViewerSsoDomain
         $result = Get-TeamViewerSsoInclusion -ApiToken $testApiToken -Domain $testDomain
         $result | Should -HaveCount 3
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq "//unit.test/ssoDomain/$testDomainId/inclusion" -And `
                 $Method -eq 'Get' }

--- a/Tests/Public/Get-TeamViewerUser.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerUser.Tests.ps1
@@ -21,14 +21,14 @@ Describe 'Get-TeamViewerUser' {
     It 'Should call the correct API endpoint to list users' {
         Get-TeamViewerUser -ApiToken $testApiToken
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And $Uri -eq '//unit.test/users' -And $Method -eq 'Get' }
     }
 
     It 'Should call the correct API endpoint for single user' {
         Get-TeamViewerUser -ApiToken $testApiToken -User 'u1234'
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And $Uri -eq '//unit.test/users/u1234' -And $Method -eq 'Get' }
     }
 
@@ -41,34 +41,34 @@ Describe 'Get-TeamViewerUser' {
     It 'Should allow to filter by name' {
         Get-TeamViewerUser -ApiToken $testApiToken -Name 'TestName'
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $Body -And $Body['name'] -eq 'TestName' }
     }
 
     It 'Should allow to filter by emails' {
         Get-TeamViewerUser -ApiToken $testApiToken -Email 'user1@unit.test', 'user2@unit.test'
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $Body -And $Body['email'] -eq 'user1@unit.test,user2@unit.test' }
     }
 
     It 'Should allow to filter by permissions' {
         Get-TeamViewerUser -ApiToken $testApiToken -Permissions 'p1', 'p2', 'p3'
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $Body -And $Body['permissions'] -eq 'p1,p2,p3' }
     }
-    
+
     It 'Should allow to retrieve all properties' {
         Get-TeamViewerUser -ApiToken $testApiToken -PropertiesToLoad 'All'
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $Body -And $Body['full_list'] -eq $true }
     }
 
     It 'Should allow to retrieve a minimal set of properties' {
         Get-TeamViewerUser -ApiToken $testApiToken -PropertiesToLoad 'Minimal'
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $Body -And $Body['full_list'] -eq $null }
     }
 }

--- a/Tests/Public/Get-TeamViewerUserByRole.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerUserByRole.Tests.ps1
@@ -22,7 +22,7 @@ Describe 'Get-TeamViewerUserByRole' {
         It 'Should call the correct API endpoint' {
             Get-TeamViewerUserByRole -ApiToken $testApiToken -RoleId $testRoleId
 
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
                 $ApiToken -eq $testApiToken -And `
                     $Uri -eq "//unit.test/userroles/assignments/account?userRoleId=$testRoleId" -And `
                     $Method -eq 'Get'

--- a/Tests/Public/Get-TeamViewerUserGroup.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerUserGroup.Tests.ps1
@@ -30,7 +30,7 @@ Describe 'Get-TeamViewerUserGroup' {
         It 'Should call the correct API endpoint to list user groups' {
             Get-TeamViewerUserGroup -ApiToken $testApiToken
 
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
                 $ApiToken -eq $testApiToken -And `
                     $Uri -eq '//unit.test/usergroups' -And `
                     $Method -eq 'Get' }
@@ -57,7 +57,7 @@ Describe 'Get-TeamViewerUserGroup' {
             $result = Get-TeamViewerUserGroup -ApiToken $testApiToken
             $result | Should -HaveCount 4
 
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 2 -Scope It
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 2 -Scope It
         }
     }
 
@@ -69,7 +69,7 @@ Describe 'Get-TeamViewerUserGroup' {
         It 'Should call the correct API endpoint for single user group' {
             Get-TeamViewerUserGroup -ApiToken $testApiToken -UserGroup $testUserGroupId
 
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
                 $ApiToken -eq $testApiToken -And `
                     $Uri -eq "//unit.test/usergroups/$testUserGroupId" -And `
                     $Method -eq 'Get' }
@@ -79,7 +79,7 @@ Describe 'Get-TeamViewerUserGroup' {
             $testUserGroup = @{Id = $testUserGroupId; Name = 'test user group' } | ConvertTo-TeamViewerUserGroup
             Get-TeamViewerUserGroup -ApiToken $testApiToken -UserGroup $testUserGroup
 
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
                 $ApiToken -eq $testApiToken -And `
                     $Uri -eq "//unit.test/usergroups/$testUserGroupId" -And `
                     $Method -eq 'Get' }

--- a/Tests/Public/Get-TeamViewerUserGroupByRole.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerUserGroupByRole.Tests.ps1
@@ -22,7 +22,7 @@ Describe 'Get-TeamViewerUserGroupByRole' {
         It 'Should call the correct API endpoint' {
             Get-TeamViewerUserGroupByRole -ApiToken $testApiToken -RoleId $testRoleId
 
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
                 $ApiToken -eq $testApiToken -And `
                     $Uri -eq "//unit.test/userroles/assignments/usergroups?userRoleId=$testRoleId" -And `
                     $Method -eq 'Get'

--- a/Tests/Public/Get-TeamViewerUserGroupMember.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerUserGroupMember.Tests.ps1
@@ -26,7 +26,7 @@ Describe 'Get-TeamViewerUserGroupMember' {
     It 'Should call the correct API endpoint to list user group members' {
         Get-TeamViewerUserGroupMember -ApiToken $testApiToken -UserGroup $testUserGroupId
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
             $Uri -eq "//unit.test/usergroups/$testUserGroupId/members" -And `
             $Method -eq 'Get' }
@@ -36,7 +36,7 @@ Describe 'Get-TeamViewerUserGroupMember' {
         $testUserGroup = @{Id = $testUserGroupId; Name = 'test user group' } | ConvertTo-TeamViewerUserGroup
         Get-TeamViewerUserGroupMember -ApiToken $testApiToken -UserGroup $testUserGroup
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
             $Uri -eq "//unit.test/usergroups/$testUserGroupId/members" -And `
             $Method -eq 'Get' }
@@ -67,6 +67,6 @@ Describe 'Get-TeamViewerUserGroupMember' {
             -UserGroup $testUserGroupId
         $result | Should -HaveCount 4
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 2 -Scope It
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 2 -Scope It
     }
 }

--- a/Tests/Public/Get-TeamViewerVersion.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerVersion.Tests.ps1
@@ -18,7 +18,7 @@ Describe 'Get-TeamViewerVersion' {
 
         It 'Should return the TeamViewer Version from the Windows Registry' {
             Get-TeamViewerVersion | Should -Be '15.10.0'
-            Assert-MockCalled Get-ItemPropertyValue -Scope It -Times 1 -ParameterFilter {
+            Should -Invoke Get-ItemPropertyValue -Scope It -Times 1 -ParameterFilter {
                 $Path -Eq 'testRegistry' -And $Name -Eq 'Version'
             }
         }
@@ -33,7 +33,7 @@ Describe 'Get-TeamViewerVersion' {
 
         It 'Should return the TeamViewer version from the global configuration' {
             Get-TeamViewerVersion | Should -Be '15.10.0'
-            Assert-MockCalled Get-TeamViewerLinuxGlobalConfig -Scope It -Times 1 -ParameterFilter {
+            Should -Invoke Get-TeamViewerLinuxGlobalConfig -Scope It -Times 1 -ParameterFilter {
                 $Name -Eq 'Version'
             }
         }
@@ -42,7 +42,7 @@ Describe 'Get-TeamViewerVersion' {
     It 'Should return nothing if TeamViewer is not installed' {
         Mock Test-TeamViewerInstallation { $false }
         Get-TeamViewerVersion | Should -BeNullOrEmpty
-        Assert-MockCalled Get-ItemPropertyValue -Scope It -Times 0
+        Should -Invoke Get-ItemPropertyValue -Scope It -Times 0
     }
 
     It 'Should return nothing on unsupported platforms' {

--- a/Tests/Public/Invoke-TeamViewerPing.Tests.ps1
+++ b/Tests/Public/Invoke-TeamViewerPing.Tests.ps1
@@ -16,7 +16,7 @@ Describe 'Invoke-TeamViewerPing' {
     It 'Should call the correct API endpoint' {
         Invoke-TeamViewerPing -ApiToken $testApiToken
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/ping' -And `
                 $Method -eq 'Get' }

--- a/Tests/Public/Move-TeamViewerManagedDevice.Tests.ps1
+++ b/Tests/Public/Move-TeamViewerManagedDevice.Tests.ps1
@@ -25,7 +25,7 @@ Describe 'Move-TeamViewerManagedDevice' {
             -Device $testDeviceId `
             -SourceGroup $testSourceGroupId `
             -TargetGroup $testTargetGroupId
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq "//unit.test/managed/devices/$testDeviceId/groups" -And `
                 $Method -eq 'Put' }

--- a/Tests/Public/New-TeamViewerContact.Tests.ps1
+++ b/Tests/Public/New-TeamViewerContact.Tests.ps1
@@ -22,7 +22,7 @@ BeforeAll {
 Describe 'New-TeamViewerContact' {
     It 'Should call the correct API endpoint' {
         New-TeamViewerContact -ApiToken $testApiToken -Email 'unit@example.test' -Group 'g5678'
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/contacts' -And `
                 $Method -eq 'Post' }

--- a/Tests/Public/New-TeamViewerDevice.Tests.ps1
+++ b/Tests/Public/New-TeamViewerDevice.Tests.ps1
@@ -29,7 +29,7 @@ BeforeAll {
 Describe 'New-TeamViewerDevice' {
     It 'Should call the correct API endpoint' {
         New-TeamViewerDevice -ApiToken $testApiToken -TeamViewerId 1234 -Group 'g5678'
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/devices' -And `
                 $Method -eq 'Post' }

--- a/Tests/Public/New-TeamViewerGroup.Tests.ps1
+++ b/Tests/Public/New-TeamViewerGroup.Tests.ps1
@@ -17,7 +17,7 @@ Describe 'New-TeamViewerGroup' {
     It 'Should call the correct API endpoint' {
         New-TeamViewerGroup -ApiToken $testApiToken -Name 'Unit Test Group'
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/groups' -And `
                 $Method -eq 'Post' }

--- a/Tests/Public/New-TeamViewerManagedGroup.Tests.ps1
+++ b/Tests/Public/New-TeamViewerManagedGroup.Tests.ps1
@@ -23,7 +23,7 @@ Describe 'New-TeamViewerManagedGroup' {
     It 'Should call the correct API endpoint' {
         New-TeamViewerManagedGroup -ApiToken $testApiToken -Name 'Unit Test ManagedGroup'
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/managed/groups' -And `
                 $Method -eq 'Post' }

--- a/Tests/Public/New-TeamViewerPolicy.Tests.ps1
+++ b/Tests/Public/New-TeamViewerPolicy.Tests.ps1
@@ -16,7 +16,7 @@ Describe 'New-TeamViewerPolicy' {
     It 'Should call the correct API endpoint' {
         New-TeamViewerPolicy -ApiToken $testApiToken -Name 'Unit Test Policy'
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/teamviewerpolicies' -And `
                 $Method -eq 'Post' }

--- a/Tests/Public/New-TeamViewerRole.tests.ps1
+++ b/Tests/Public/New-TeamViewerRole.tests.ps1
@@ -27,7 +27,7 @@ Describe 'New-TeamViewerRole' {
     It 'Should call the correct API endpoint' {
         New-TeamViewerRole -ApiToken $testApiToken -Name $testRoleName
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/userroles' -And `
                 $Method -eq 'Post'

--- a/Tests/Public/New-TeamViewerUser.Tests.ps1
+++ b/Tests/Public/New-TeamViewerUser.Tests.ps1
@@ -26,7 +26,7 @@ Describe 'New-TeamViewerUser' {
     It 'Should call the correct API endpoint' {
         New-TeamViewerUser -ApiToken $testApiToken -Name 'Unit Test User' -Email 'user1@unit.test' -WithoutPassword
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And $Uri -eq '//unit.test/users' -And $Method -eq 'Post' }
     }
 

--- a/Tests/Public/New-TeamViewerUserGroup.Tests.ps1
+++ b/Tests/Public/New-TeamViewerUserGroup.Tests.ps1
@@ -25,7 +25,7 @@ Describe 'New-TeamViewerUserGroup' {
     It 'Should call the correct API endpoint' {
         New-TeamViewerUserGroup -ApiToken $testApiToken -Name $testUserGroupName
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
             $Uri -eq '//unit.test/usergroups' -And `
             $Method -eq 'Post' }

--- a/Tests/Public/Publish-TeamViewerGroup.Tests.ps1
+++ b/Tests/Public/Publish-TeamViewerGroup.Tests.ps1
@@ -14,7 +14,7 @@ Describe 'Publish-TeamViewerGroup' {
     It 'Should call the correct API endpoint' {
         Publish-TeamViewerGroup -ApiToken $testApiToken -Group 'g1234' -User 'u1234' -Permissions 'readwrite'
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/groups/g1234/share_group' -And `
                 $Method -eq 'Post' }
@@ -37,7 +37,7 @@ Describe 'Publish-TeamViewerGroup' {
         $testGroup = @{ id = 'g1234'; name = 'test group' } | ConvertTo-TeamViewerGroup
         Publish-TeamViewerGroup -ApiToken $testApiToken -Group $testGroup -User 'u1234'
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/groups/g1234/share_group' -And `
                 $Method -eq 'Post' }

--- a/Tests/Public/Remove-TeamViewerAssignment.Tests.ps1
+++ b/Tests/Public/Remove-TeamViewerAssignment.Tests.ps1
@@ -25,7 +25,7 @@ Describe 'Remove-TeamViewerAssignment' {
 
         It 'Should set the location to the installation directory' {
             Remove-TeamViewerAssignment
-            Assert-MockCalled Set-Location -Scope It -Times 1 -ParameterFilter {
+            Should -Invoke Set-Location -Scope It -Times 1 -ParameterFilter {
                 $Path -eq 'testPath'
             }
         }
@@ -34,14 +34,14 @@ Describe 'Remove-TeamViewerAssignment' {
         It 'Should call TeamViewer.exe unassignment' {
             Mock Start-Process -ParameterFilter { $_.FilePath -eq 'TeamViewer.exe' -and $_.ArgumentList -eq 'unassign' }
             Remove-TeamViewerAssignment
-            Assert-MockCalled Start-Process -Scope It -Times 1
+            Should -Invoke Start-Process -Scope It -Times 1
         }
 
         It 'Should restore the current directory after calling cmd.exe' {
             Mock cmd.exe {}
             $currentDirectory = Get-Location
             Remove-TeamViewerAssignment
-            Assert-MockCalled Set-Location -Scope It -Times 1 -ParameterFilter {
+            Should -Invoke Set-Location -Scope It -Times 1 -ParameterFilter {
                 $Path -eq $currentDirectory
             }
         }

--- a/Tests/Public/Remove-TeamViewerContact.Tests.ps1
+++ b/Tests/Public/Remove-TeamViewerContact.Tests.ps1
@@ -14,7 +14,7 @@ BeforeAll {
 Describe 'Remove-TeamViewerContact' {
     It 'Should call the correct API endpoint' {
         Remove-TeamViewerContact -ApiToken $testApiToken -Id 'c1234'
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/contacts/c1234' -And `
                 $Method -eq 'Delete' }
@@ -23,7 +23,7 @@ Describe 'Remove-TeamViewerContact' {
     It 'Should accept Contact objects' {
         $testContact = @{ contact_id = 'c1234' } | ConvertTo-TeamViewerContact
         Remove-TeamViewerContact -ApiToken $testApiToken -Contact $testContact
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/contacts/c1234' -And `
                 $Method -eq 'Delete' }
@@ -32,7 +32,7 @@ Describe 'Remove-TeamViewerContact' {
     It 'Should accept pipeline input' {
         $testContact = @{ contact_id = 'c1234' } | ConvertTo-TeamViewerContact
         $testContact | Remove-TeamViewerContact -ApiToken $testApiToken
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/contacts/c1234' -And `
                 $Method -eq 'Delete' }

--- a/Tests/Public/Remove-TeamViewerCustomization.Tests.ps1
+++ b/Tests/Public/Remove-TeamViewerCustomization.Tests.ps1
@@ -24,13 +24,13 @@ Describe 'Remove-TeamViewerCustomization' {
         It 'Should call TeamViewer.exe customize --remove' {
             Mock Start-Process -ParameterFilter { $_.FilePath -eq 'TeamViewer.exe' -and $_.ArgumentList -eq 'customize --remove"' }
             Remove-TeamViewerCustomization
-            Assert-MockCalled Start-Process -Scope It -Times 1
+            Should -Invoke Start-Process -Scope It -Times 1
         }
 
         It 'Should resolve the customization error code' {
             Mock Resolve-CustomizationErrorCode {}
             Remove-TeamViewerCustomization
-            Assert-MockCalled Resolve-CustomizationErrorCode -Scope It -Times 1
+            Should -Invoke Resolve-CustomizationErrorCode -Scope It -Times 1
         }
     }
 
@@ -44,8 +44,8 @@ Describe 'Remove-TeamViewerCustomization' {
         It 'Should write an error message' {
             Mock Write-Error -ParameterFilter { $_ -eq 'TeamViewer is not installed' }
             Remove-TeamViewerCustomization
-            Assert-MockCalled Start-Process -Scope It -Times 0
-            Assert-MockCalled Write-Error -Scope It -Times 1
+            Should -Invoke Start-Process -Scope It -Times 0
+            Should -Invoke Write-Error -Scope It -Times 1
         }
     }
 }

--- a/Tests/Public/Remove-TeamViewerDevice.Tests.ps1
+++ b/Tests/Public/Remove-TeamViewerDevice.Tests.ps1
@@ -14,7 +14,7 @@ BeforeAll {
 Describe 'Remove-TeamViewerDevice' {
     It 'Should call the correct API endpoint' {
         Remove-TeamViewerDevice -ApiToken $testApiToken -Id 'd1234'
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/devices/d1234' -And `
                 $Method -eq 'Delete' }
@@ -23,7 +23,7 @@ Describe 'Remove-TeamViewerDevice' {
     It 'Should accept Device objects' {
         $testDeviceObj = @{ device_id = 'd1234' } | ConvertTo-TeamViewerDevice
         Remove-TeamViewerDevice -ApiToken $testApiToken -Device $testDeviceObj
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/devices/d1234' -And `
                 $Method -eq 'Delete' }
@@ -32,7 +32,7 @@ Describe 'Remove-TeamViewerDevice' {
     It 'Should accept pipeline input' {
         $testDeviceObj = @{ device_id = 'd1234' } | ConvertTo-TeamViewerDevice
         $testDeviceObj | Remove-TeamViewerDevice -ApiToken $testApiToken
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/devices/d1234' -And `
                 $Method -eq 'Delete' }

--- a/Tests/Public/Remove-TeamViewerGroup.Tests.ps1
+++ b/Tests/Public/Remove-TeamViewerGroup.Tests.ps1
@@ -15,7 +15,7 @@ Describe 'Remove-TeamViewerGroup' {
     It 'Should call the correct API endpoint' {
         Remove-TeamViewerGroup -ApiToken $testApiToken -Group 'g1234'
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/groups/g1234' -And `
                 $Method -eq 'Delete' }
@@ -25,7 +25,7 @@ Describe 'Remove-TeamViewerGroup' {
         $testGroup = @{ id = 'g1234' } | ConvertTo-TeamViewerGroup
         Remove-TeamViewerGroup -ApiToken $testApiToken -Group $testGroup
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/groups/g1234' -And `
                 $Method -eq 'Delete' }
@@ -39,7 +39,7 @@ Describe 'Remove-TeamViewerGroup' {
         $testGroup = @{ id = 'g1234' } | ConvertTo-TeamViewerGroup
         $testGroup | Remove-TeamViewerGroup -ApiToken $testApiToken
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/groups/g1234' -And `
                 $Method -eq 'Delete' }

--- a/Tests/Public/Remove-TeamViewerManagedDevice.Tests.ps1
+++ b/Tests/Public/Remove-TeamViewerManagedDevice.Tests.ps1
@@ -19,7 +19,7 @@ Describe 'Remove-TeamViewerManagedDevice' {
     It 'Should call the correct API endpoint' {
         Remove-TeamViewerManagedDevice -ApiToken $testApiToken -DeviceId $testDeviceId -GroupId $testGroupId
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq "//unit.test/managed/groups/$testGroupId/devices/$testDeviceId" -And `
                 $Method -eq 'Delete' }
@@ -29,7 +29,7 @@ Describe 'Remove-TeamViewerManagedDevice' {
         $testGroup = @{ id = $testGroupId } | ConvertTo-TeamViewerManagedGroup
         Remove-TeamViewerManagedDevice -ApiToken $testApiToken -DeviceId $testDeviceId -Group $testGroup
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq "//unit.test/managed/groups/$testGroupId/devices/$testDeviceId" -And `
                 $Method -eq 'Delete' }
@@ -39,7 +39,7 @@ Describe 'Remove-TeamViewerManagedDevice' {
         $testDeviceObj = @{ id = $testDeviceId } | ConvertTo-TeamViewerManagedDevice
         Remove-TeamViewerManagedDevice -ApiToken $testApiToken -Device $testDeviceObj -GroupId $testGroupId
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq "//unit.test/managed/groups/$testGroupId/devices/$testDeviceId" -And `
                 $Method -eq 'Delete' }
@@ -49,7 +49,7 @@ Describe 'Remove-TeamViewerManagedDevice' {
         $testDeviceObj = @{ id = $testDeviceId } | ConvertTo-TeamViewerManagedDevice
         $testDeviceObj | Remove-TeamViewerManagedDevice -ApiToken $testApiToken -GroupId $testGroupId
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq "//unit.test/managed/groups/$testGroupId/devices/$testDeviceId" -And `
                 $Method -eq 'Delete' }

--- a/Tests/Public/Remove-TeamViewerManagedDeviceManagement.Tests.ps1
+++ b/Tests/Public/Remove-TeamViewerManagedDeviceManagement.Tests.ps1
@@ -17,7 +17,7 @@ Describe 'Remove-TeamViewerManagedDeviceManagement' {
     It 'Should call the correct API endpoint' {
         Remove-TeamViewerManagedDeviceManagement -ApiToken $testApiToken -DeviceId $testDeviceId
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq "//unit.test/managed/devices/$testDeviceId" -And `
                 $Method -eq 'Delete' }
@@ -27,7 +27,7 @@ Describe 'Remove-TeamViewerManagedDeviceManagement' {
         $testDeviceObj = @{ id = $testDeviceId } | ConvertTo-TeamViewerManagedDevice
         Remove-TeamViewerManagedDeviceManagement -ApiToken $testApiToken -Device $testDeviceObj
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq "//unit.test/managed/devices/$testDeviceId" -And `
                 $Method -eq 'Delete' }
@@ -37,7 +37,7 @@ Describe 'Remove-TeamViewerManagedDeviceManagement' {
         $testDeviceObj = @{ id = $testDeviceId } | ConvertTo-TeamViewerManagedDevice
         $testDeviceObj | Remove-TeamViewerManagedDeviceManagement -ApiToken $testApiToken
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq "//unit.test/managed/devices/$testDeviceId" -And `
                 $Method -eq 'Delete' }

--- a/Tests/Public/Remove-TeamViewerManagedGroup.Tests.ps1
+++ b/Tests/Public/Remove-TeamViewerManagedGroup.Tests.ps1
@@ -17,7 +17,7 @@ Describe 'Remove-TeamViewerGroup' {
     It 'Should call the correct API endpoint' {
         Remove-TeamViewerManagedGroup -ApiToken $testApiToken -Id $testGroupId
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq "//unit.test/managed/groups/$testGroupId" -And `
                 $Method -eq 'Delete' }
@@ -27,7 +27,7 @@ Describe 'Remove-TeamViewerGroup' {
         $testGroup = @{ id = $testGroupId } | ConvertTo-TeamViewerManagedGroup
         Remove-TeamViewerManagedGroup -ApiToken $testApiToken -Group $testGroup
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq "//unit.test/managed/groups/$testGroupId" -And `
                 $Method -eq 'Delete' }
@@ -41,7 +41,7 @@ Describe 'Remove-TeamViewerGroup' {
         $testGroup = @{ id = $testGroupId } | ConvertTo-TeamViewerManagedGroup
         $testGroup | Remove-TeamViewerManagedGroup -ApiToken $testApiToken
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq "//unit.test/managed/groups/$testGroupId" -And `
                 $Method -eq 'Delete' }

--- a/Tests/Public/Remove-TeamViewerManager.Tests.ps1
+++ b/Tests/Public/Remove-TeamViewerManager.Tests.ps1
@@ -24,7 +24,7 @@ Describe 'Remove-TeamViewerManager' {
                 -ApiToken $testApiToken `
                 -GroupId $testGroupId `
                 -ManagerId $testManagerId
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
                 $ApiToken -eq $testApiToken -And `
                     $Uri -eq "//unit.test/managed/groups/$testGroupId/managers/$testManagerId" -And `
                     $Method -eq 'Delete' }
@@ -35,7 +35,7 @@ Describe 'Remove-TeamViewerManager' {
             Remove-TeamViewerManager `
                 -ApiToken $testApiToken `
                 -Manager $testManager
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
                 $ApiToken -eq $testApiToken -And `
                     $Uri -eq "//unit.test/managed/groups/$testGroupId/managers/$testManagerId" -And `
                     $Method -eq 'Delete' }
@@ -44,7 +44,7 @@ Describe 'Remove-TeamViewerManager' {
         It 'Should accept pipeline objects' {
             $testManager = @{id = $testManagerId } | ConvertTo-TeamViewerManager -GroupId $testGroupId
             $testManager | Remove-TeamViewerManager -ApiToken $testApiToken
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
                 $ApiToken -eq $testApiToken -And `
                     $Uri -eq "//unit.test/managed/groups/$testGroupId/managers/$testManagerId" -And `
                     $Method -eq 'Delete' }
@@ -66,7 +66,7 @@ Describe 'Remove-TeamViewerManager' {
                 -ApiToken $testApiToken `
                 -DeviceId $testDeviceId `
                 -ManagerId $testManagerId
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
                 $ApiToken -eq $testApiToken -And `
                     $Uri -eq "//unit.test/managed/devices/$testDeviceId/managers/$testManagerId" -And `
                     $Method -eq 'Delete' }
@@ -77,7 +77,7 @@ Describe 'Remove-TeamViewerManager' {
             Remove-TeamViewerManager `
                 -ApiToken $testApiToken `
                 -Manager $testManager
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
                 $ApiToken -eq $testApiToken -And `
                     $Uri -eq "//unit.test/managed/devices/$testDeviceId/managers/$testManagerId" -And `
                     $Method -eq 'Delete' }
@@ -86,7 +86,7 @@ Describe 'Remove-TeamViewerManager' {
         It 'Should accept pipeline objects' {
             $testManager = @{id = $testManagerId } | ConvertTo-TeamViewerManager -DeviceId $testDeviceId
             $testManager | Remove-TeamViewerManager -ApiToken $testApiToken
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
                 $ApiToken -eq $testApiToken -And `
                     $Uri -eq "//unit.test/managed/devices/$testDeviceId/managers/$testManagerId" -And `
                     $Method -eq 'Delete' }

--- a/Tests/Public/Remove-TeamViewerPolicy.Tests.ps1
+++ b/Tests/Public/Remove-TeamViewerPolicy.Tests.ps1
@@ -19,7 +19,7 @@ Describe 'Remove-TeamViewerPolicy' {
         Remove-TeamViewerPolicy `
             -ApiToken $testApiToken `
             -PolicyId $testPolicyId
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq "//unit.test/teamviewerpolicies/$testPolicyId" -And `
                 $Method -eq 'Delete' }
@@ -30,7 +30,7 @@ Describe 'Remove-TeamViewerPolicy' {
         Remove-TeamViewerPolicy `
             -ApiToken $testApiToken `
             -Policy $testPolicyObj
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq "//unit.test/teamviewerpolicies/$testPolicyId" -And `
                 $Method -eq 'Delete' }
@@ -39,7 +39,7 @@ Describe 'Remove-TeamViewerPolicy' {
     It 'Should accept pipeline input' {
         $testPolicyObj = @{ policy_id = $testPolicyId } | ConvertTo-TeamViewerPolicy
         $testPolicyObj | Remove-TeamViewerPolicy -ApiToken $testApiToken
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq "//unit.test/teamviewerpolicies/$testPolicyId" -And `
                 $Method -eq 'Delete' }

--- a/Tests/Public/Remove-TeamViewerPolicyFromManagedDevice.Tests.ps1
+++ b/Tests/Public/Remove-TeamViewerPolicyFromManagedDevice.Tests.ps1
@@ -19,7 +19,7 @@ Describe 'Remove-TeamViewerPolicyFromManagedDevice' {
 
     It 'Should call the correct API endpoint to remove a policy from the managed device' {
         Remove-TeamViewerPolicyFromManagedDevice -ApiToken $testApiToken -Device $testDeviceId -PolicyType TeamViewer
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq "//unit.test/managed/devices/$testDeviceId/policy/remove" -And `
                 $Method -eq 'Put' }

--- a/Tests/Public/Remove-TeamViewerPolicyFromManagedGroup.Tests.ps1
+++ b/Tests/Public/Remove-TeamViewerPolicyFromManagedGroup.Tests.ps1
@@ -19,7 +19,7 @@ Describe 'Remove-TeamViewerPolicyFromManagedGroup' {
 
     It 'Should call the correct API endpoint to remove a policy from the managed group' {
         Remove-TeamViewerPolicyFromManagedGroup -ApiToken $testApiToken -Group $testGroupId -PolicyType TeamViewer
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq "//unit.test/managed/groups/$testGroupId/policy/remove" -And `
                 $Method -eq 'Put' }

--- a/Tests/Public/Remove-TeamViewerPredefinedRole.Tests.ps1
+++ b/Tests/Public/Remove-TeamViewerPredefinedRole.Tests.ps1
@@ -16,7 +16,7 @@ Describe 'Remove-TeamViewerPredefinedRole' {
     It 'Should call the correct API endpoint to remove PredefinedRole' {
         Remove-TeamViewerPredefinedRole -ApiToken $testApiToken
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq "//unit.test/userroles/predefined" -And `
                 $Method -eq 'Delete' }

--- a/Tests/Public/Remove-TeamViewerRole.Tests.ps1
+++ b/Tests/Public/Remove-TeamViewerRole.Tests.ps1
@@ -17,7 +17,7 @@ Describe 'Remove-TeamViewerRole' {
     It 'Should call the correct API endpoint' {
         Remove-TeamViewerRole -ApiToken $testApiToken -RoleId $testRoleId
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq "//unit.test/userroles?userRoleId=$testRoleId" -And `
                 $Method -eq 'Delete'
@@ -28,7 +28,7 @@ Describe 'Remove-TeamViewerRole' {
         $testRole = @{Id = $testRoleId; Name = 'test user role' } | ConvertTo-TeamViewerRole
         Remove-TeamViewerRole -ApiToken $testApiToken -RoleId $testRole.RoleID
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq "//unit.test/userroles?userRoleId=$testRoleId" -And `
                 $Method -eq 'Delete'

--- a/Tests/Public/Remove-TeamViewerSsoExclusion.Tests.ps1
+++ b/Tests/Public/Remove-TeamViewerSsoExclusion.Tests.ps1
@@ -20,7 +20,7 @@ Describe 'Remove-TeamViewerSsoExclusion' {
             -ApiToken $testApiToken `
             -DomainId $testDomainId `
             -Email 'foo@example.test'
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq "//unit.test/ssoDomain/$testDomainId/exclusion" -And `
                 $Method -eq 'Delete' }
@@ -53,7 +53,7 @@ Describe 'Remove-TeamViewerSsoExclusion' {
             -ApiToken $testApiToken `
             -Domain $testDomain `
             -Email 'foo@example.test'
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq "//unit.test/ssoDomain/$testDomainId/exclusion" -And `
                 $Method -eq 'Delete' }
@@ -65,7 +65,7 @@ Describe 'Remove-TeamViewerSsoExclusion' {
         $testAddresses | Remove-TeamViewerSsoExclusion `
             -ApiToken $testApiToken `
             -DomainId $testDomainId
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 3 -Scope It
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 3 -Scope It
         $mockArgs.Body | Should -Not -BeNullOrEmpty
         $body = [System.Text.Encoding]::UTF8.GetString($mockArgs.Body) | ConvertFrom-Json
         $body.emails | Should -HaveCount 50

--- a/Tests/Public/Remove-TeamViewerSsoInclusion.Tests.ps1
+++ b/Tests/Public/Remove-TeamViewerSsoInclusion.Tests.ps1
@@ -20,7 +20,7 @@ Describe 'Remove-TeamViewerSsoInclusion' {
             -ApiToken $testApiToken `
             -DomainId $testDomainId `
             -Email 'foo@example.test'
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq "//unit.test/ssoDomain/$testDomainId/inclusion" -And `
                 $Method -eq 'Delete' }
@@ -53,7 +53,7 @@ Describe 'Remove-TeamViewerSsoInclusion' {
             -ApiToken $testApiToken `
             -Domain $testDomain `
             -Email 'foo@example.test'
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq "//unit.test/ssoDomain/$testDomainId/inclusion" -And `
                 $Method -eq 'Delete' }
@@ -65,7 +65,7 @@ Describe 'Remove-TeamViewerSsoInclusion' {
         $testAddresses | Remove-TeamViewerSsoInclusion `
             -ApiToken $testApiToken `
             -DomainId $testDomainId
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 3 -Scope It
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 3 -Scope It
         $mockArgs.Body | Should -Not -BeNullOrEmpty
         $body = [System.Text.Encoding]::UTF8.GetString($mockArgs.Body) | ConvertFrom-Json
         $body.emails | Should -HaveCount 50

--- a/Tests/Public/Remove-TeamViewerUser.Tests.ps1
+++ b/Tests/Public/Remove-TeamViewerUser.Tests.ps1
@@ -15,7 +15,7 @@ Describe 'Remove-TeamViewerUser' {
     It 'Should call the correct API endpoint' {
         Remove-TeamViewerUser -ApiToken $testApiToken -User 'u1234'
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/users/u1234' -And `
                 $Method -eq 'Delete' }
@@ -25,7 +25,7 @@ Describe 'Remove-TeamViewerUser' {
         $testUser = @{ id = 'u1234' } | ConvertTo-TeamViewerUser
         Remove-TeamViewerUser -ApiToken $testApiToken -User $testUser
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/users/u1234' -And `
                 $Method -eq 'Delete' }
@@ -39,7 +39,7 @@ Describe 'Remove-TeamViewerUser' {
         $testUser = @{ id = 'u1234' } | ConvertTo-TeamViewerUser
         $testUser | Remove-TeamViewerUser -ApiToken $testApiToken
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/users/u1234' -And `
                 $Method -eq 'Delete' }
@@ -49,7 +49,7 @@ Describe 'Remove-TeamViewerUser' {
         $testUser = @{ id = 'u1234' } | ConvertTo-TeamViewerUser
         Remove-TeamViewerUser -ApiToken $testApiToken -User $testUser -Permanent
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/users/u1234?isPermanentDelete=true' -And `
                 $Method -eq 'Delete' }

--- a/Tests/Public/Remove-TeamViewerUserFromRole.Tests.ps1
+++ b/Tests/Public/Remove-TeamViewerUserFromRole.Tests.ps1
@@ -24,7 +24,7 @@ Describe 'Remove-TeamViewerUserFromRole' {
     It 'Should call the correct API endpoint' {
         Remove-TeamViewerUserFromRole -ApiToken $testApiToken -RoleId $testRoleId -Accounts $testAccount
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/userroles/unassign/account' -And `
                 $Method -eq 'Post'

--- a/Tests/Public/Remove-TeamViewerUserGroup.Tests.ps1
+++ b/Tests/Public/Remove-TeamViewerUserGroup.Tests.ps1
@@ -18,7 +18,7 @@ Describe 'Remove-TeamViewerUserGroup' {
     It 'Should call the correct API endpoint' {
         Remove-TeamViewerUserGroup -ApiToken $testApiToken -UserGroup $testUserGroupId
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
             $Uri -eq "//unit.test/usergroups/$testUserGroupId" -And `
             $Method -eq 'Delete'
@@ -29,7 +29,7 @@ Describe 'Remove-TeamViewerUserGroup' {
         $testUserGroup = @{Id = $testUserGroupId; Name = 'test user group' } | ConvertTo-TeamViewerUserGroup
         Remove-TeamViewerUserGroup -ApiToken $testApiToken -UserGroup $testUserGroup
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
             $Uri -eq "//unit.test/usergroups/$testUserGroupId" -And `
             $Method -eq 'Delete'

--- a/Tests/Public/Remove-TeamViewerUserGroupFromRole.Tests.ps1
+++ b/Tests/Public/Remove-TeamViewerUserGroupFromRole.Tests.ps1
@@ -22,7 +22,7 @@ Describe 'Remove-TeamViewerUserGroupFromRole' {
     It 'Should call the correct API endpoint' {
         Remove-TeamViewerUserGroupFromRole -ApiToken $testApiToken -UserGroup $testUserGroup
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/userroles/unassign/usergroup' -And `
                 $Method -eq 'Post'

--- a/Tests/Public/Remove-TeamViewerUserGroupMember.Tests.ps1
+++ b/Tests/Public/Remove-TeamViewerUserGroupMember.Tests.ps1
@@ -32,7 +32,7 @@ Describe 'Remove-TeamViewerUserGroupMember' {
                 -ApiToken $testApiToken `
                 -UserGroup $testUserGroupId `
                 -UserGroupMember $testUserGroupMember
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
                 $ApiToken -eq $testApiToken -And `
                     $Uri -eq "//unit.test/usergroups/$testUserGroupId/members" -And `
                     $Method -eq 'Delete' }
@@ -55,7 +55,7 @@ Describe 'Remove-TeamViewerUserGroupMember' {
                 -ApiToken $testApiToken `
                 -UserGroup $testUserGroup `
                 -UserGroupMember $testUserGroupMember
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
                 $ApiToken -eq $testApiToken -And `
                     $Uri -eq "//unit.test/usergroups/$testUserGroupId/members" -And `
                     $Method -eq 'Delete' }

--- a/Tests/Public/Remove-TeamViewerUserTFA.Tests.ps1
+++ b/Tests/Public/Remove-TeamViewerUserTFA.Tests.ps1
@@ -15,7 +15,7 @@ Describe 'Remove-TeamViewerUser' {
     It 'Should call the correct API endpoint' {
         Remove-TeamViewerUserTFA -ApiToken $testApiToken -User 'u1234'
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/users/u1234/tfa' -And `
                 $Method -eq 'Delete' }
@@ -25,7 +25,7 @@ Describe 'Remove-TeamViewerUser' {
         $testUser = @{ id = 'u1234' } | ConvertTo-TeamViewerUser
         Remove-TeamViewerUserTFA -ApiToken $testApiToken -User $testUser
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/users/u1234/tfa' -And `
                 $Method -eq 'Delete' }
@@ -39,7 +39,7 @@ Describe 'Remove-TeamViewerUser' {
         $testUser = @{ id = 'u1234' } | ConvertTo-TeamViewerUser
         $testUser | Remove-TeamViewerUserTFA -ApiToken $testApiToken
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/users/u1234/tfa' -And `
                 $Method -eq 'Delete' }

--- a/Tests/Public/Restart-TeamViewerService.Tests.ps1
+++ b/Tests/Public/Restart-TeamViewerService.Tests.ps1
@@ -23,7 +23,7 @@ Describe 'Restart-TeamViewerService' {
         }
         It 'Should restart the TeamViewer Windows service' {
             Restart-TeamViewerService | Out-Null
-            Assert-MockCalled Restart-Service -Scope It -Times 1 -ParameterFilter {
+            Should -Invoke Restart-Service -Scope It -Times 1 -ParameterFilter {
                 $Name -eq 'UnitTestTeamViewer'
             }
         }
@@ -35,7 +35,7 @@ Describe 'Restart-TeamViewerService' {
         }
         It 'Should restart the TeamViewer daemon' {
             Restart-TeamViewerService | Out-Null
-            Assert-MockCalled Invoke-ExternalCommand -Scope It -Times 1 -ParameterFilter {
+            Should -Invoke Invoke-ExternalCommand -Scope It -Times 1 -ParameterFilter {
                 $Command -eq '/opt/teamviewer/tv_bin/script/teamviewer'
                 $CommandArgs[0] -eq 'daemon' -and $CommandArgs[1] -eq 'restart'
             }

--- a/Tests/Public/Set-TeamViewerAccount.Tests.ps1
+++ b/Tests/Public/Set-TeamViewerAccount.Tests.ps1
@@ -26,7 +26,7 @@ Describe 'Set-TeamViewerAccount' {
             -Name 'Updated Account Name' `
             -Email 'unit@example.test' `
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/account' -And `
                 $Method -eq 'Put' }

--- a/Tests/Public/Set-TeamViewerDevice.Tests.ps1
+++ b/Tests/Public/Set-TeamViewerDevice.Tests.ps1
@@ -24,7 +24,7 @@ BeforeAll {
 Describe 'Set-TeamViewerDevice' {
     It 'Should call the correct API endpoint' {
         Set-TeamViewerDevice -ApiToken $testApiToken -Id 'd1234' -Name 'My Updated Name'
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/devices/d1234' -And `
                 $Method -eq 'Put' }
@@ -48,7 +48,7 @@ Describe 'Set-TeamViewerDevice' {
     It 'Should accept Device objects' {
         $testDeviceObj = @{ device_id = 'd1234' } | ConvertTo-TeamViewerDevice
         Set-TeamViewerDevice -ApiToken $testApiToken -Device $testDeviceObj -Name 'My Updated Name'
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/devices/d1234' -And `
                 $Method -eq 'Put' }
@@ -57,7 +57,7 @@ Describe 'Set-TeamViewerDevice' {
     It 'Should accept pipeline input' {
         $testDeviceObj = @{ device_id = 'd1234' } | ConvertTo-TeamViewerDevice
         $testDeviceObj | Set-TeamViewerDevice -ApiToken $testApiToken -Name 'My Updated Name'
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/devices/d1234' -And `
                 $Method -eq 'Put' }

--- a/Tests/Public/Set-TeamViewerGroup.Tests.ps1
+++ b/Tests/Public/Set-TeamViewerGroup.Tests.ps1
@@ -18,7 +18,7 @@ Describe 'Set-TeamViewerGroup' {
     It 'Should call the correct API endpoint' {
         Set-TeamViewerGroup -ApiToken $testApiToken -GroupId 'g1234' -Name 'Unit Test Group'
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/groups/g1234' -And `
                 $Method -eq 'Put' }
@@ -44,7 +44,7 @@ Describe 'Set-TeamViewerGroup' {
         $testGroupObj = @{ id = 'g1234' } | ConvertTo-TeamViewerGroup
         Set-TeamViewerGroup -ApiToken $testApiToken -Group $testGroupObj -Name 'Unit Test Group'
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/groups/g1234' -And `
                 $Method -eq 'Put' }
@@ -54,7 +54,7 @@ Describe 'Set-TeamViewerGroup' {
         $testGroupObj = @{ id = 'g1234' } | ConvertTo-TeamViewerGroup
         $testGroupObj | Set-TeamViewerGroup -ApiToken $testApiToken -Name 'Unit Test Group'
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/groups/g1234' -And `
                 $Method -eq 'Put' }

--- a/Tests/Public/Set-TeamViewerManagedDevice.Tests.ps1
+++ b/Tests/Public/Set-TeamViewerManagedDevice.Tests.ps1
@@ -18,7 +18,7 @@ Describe 'Set-TeamViewerManagedDevice' {
 
     It 'Should call the correct API endpoint to update a managed device' {
         Set-TeamViewerManagedDevice -ApiToken $testApiToken -Device $testDeviceId -Name 'Foo Bar'
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq "//unit.test/managed/devices/$testDeviceId" -And `
                 $Method -eq 'Put' }
@@ -60,7 +60,7 @@ Describe 'Set-TeamViewerManagedDevice' {
         $body = [System.Text.Encoding]::UTF8.GetString($mockArgs.Body) | ConvertFrom-Json
         $body.deviceDescription | Should -Be 'Test description'
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq "//unit.test/managed/devices/$testDeviceId/description" -And `
                 $Method -eq 'Put'
@@ -106,7 +106,7 @@ Describe 'Set-TeamViewerManagedDevice' {
     It 'Should accept a ManagedDevice object as input' {
         $testDevice = @{ id = $testDeviceId; name = 'test device' } | ConvertTo-TeamViewerManagedDevice
         Set-TeamViewerManagedDevice -ApiToken $testApiToken -Device $testDevice -Name 'Foo Bar'
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq "//unit.test/managed/devices/$testDeviceId" -And `
                 $Method -eq 'Put' }

--- a/Tests/Public/Set-TeamViewerManagedGroup.Tests.ps1
+++ b/Tests/Public/Set-TeamViewerManagedGroup.Tests.ps1
@@ -19,7 +19,7 @@ Describe 'Set-TeamViewerManagedGroup' {
 
     It 'Should call the correct API endpoint to update managed group' {
         Set-TeamViewerManagedGroup -ApiToken $testApiToken -GroupId $testGroupId -Name 'Foo Bar'
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq "//unit.test/managed/groups/$testGroupId" -And `
                 $Method -eq 'Put' }
@@ -151,7 +151,7 @@ Describe 'Set-TeamViewerManagedGroup' {
     It 'Should accept a ManagedGroup object as input' {
         $testGroup = @{id = $testGroupId; name = 'test managed group' } | ConvertTo-TeamViewerManagedGroup
         Set-TeamViewerManagedGroup -ApiToken $testApiToken -Group $testGroup -Name 'Foo Bar'
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq "//unit.test/managed/groups/$testGroupId" -And `
                 $Method -eq 'Put' }
@@ -160,7 +160,7 @@ Describe 'Set-TeamViewerManagedGroup' {
     It 'Should accept pipeline input' {
         $testGroup = @{id = $testGroupId; name = 'test managed group' } | ConvertTo-TeamViewerManagedGroup
         $testGroup | Set-TeamViewerManagedGroup -ApiToken $testApiToken -Name 'Foo Bar'
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq "//unit.test/managed/groups/$testGroupId" -And `
                 $Method -eq 'Put' }

--- a/Tests/Public/Set-TeamViewerManager.Tests.ps1
+++ b/Tests/Public/Set-TeamViewerManager.Tests.ps1
@@ -26,7 +26,7 @@ Describe 'Set-TeamViewerManager' {
                 -GroupId $testGroupId `
                 -ManagerId $testManagerId `
                 -Permissions 'ManagerAdministration', 'EasyAccess'
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
                 $ApiToken -eq $testApiToken -And `
                     $Uri -eq "//unit.test/managed/groups/$testGroupId/managers/$testManagerId" -And `
                     $Method -eq 'Put' }
@@ -38,7 +38,7 @@ Describe 'Set-TeamViewerManager' {
                 -ApiToken $testApiToken `
                 -Manager $testManager `
                 -Permissions 'ManagerAdministration', 'EasyAccess'
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
                 $ApiToken -eq $testApiToken -And `
                     $Uri -eq "//unit.test/managed/groups/$testGroupId/managers/$testManagerId" -And `
                     $Method -eq 'Put' }
@@ -62,7 +62,7 @@ Describe 'Set-TeamViewerManager' {
                 -DeviceId $testDeviceId `
                 -ManagerId $testManagerId `
                 -Permissions 'ManagerAdministration', 'EasyAccess'
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
                 $ApiToken -eq $testApiToken -And `
                     $Uri -eq "//unit.test/managed/devices/$testDeviceId/managers/$testManagerId" -And `
                     $Method -eq 'Put' }
@@ -74,7 +74,7 @@ Describe 'Set-TeamViewerManager' {
                 -ApiToken $testApiToken `
                 -Manager $testManager `
                 -Permissions 'ManagerAdministration', 'EasyAccess'
-            Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+            Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
                 $ApiToken -eq $testApiToken -And `
                     $Uri -eq "//unit.test/managed/devices/$testDeviceId/managers/$testManagerId" -And `
                     $Method -eq 'Put' }
@@ -142,7 +142,7 @@ Describe 'Set-TeamViewerManager' {
         $testManager | Set-TeamViewerManager `
             -ApiToken $testApiToken `
             -Permissions 'ManagerAdministration', 'EasyAccess'
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq "//unit.test/managed/groups/$testGroupId/managers/$testManagerId" -And `
                 $Method -eq 'Put' }

--- a/Tests/Public/Set-TeamViewerPolicy.Tests.ps1
+++ b/Tests/Public/Set-TeamViewerPolicy.Tests.ps1
@@ -21,7 +21,7 @@ Describe 'Set-TeamViewerPolicy' {
             -PolicyId $testPolicyId `
             -Name 'Updated Policy Name'
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq "//unit.test/teamviewerpolicies/$testPolicyId" -And `
                 $Method -eq 'Put' }

--- a/Tests/Public/Set-TeamViewerPredefinedRole.Tests.ps1
+++ b/Tests/Public/Set-TeamViewerPredefinedRole.Tests.ps1
@@ -16,7 +16,7 @@ Describe 'Set-TeamViewerPredefinedRole' {
     It 'Should call the correct API endpoint' {
         Set-TeamViewerPredefinedRole -ApiToken $testApiToken -RoleId $testRoleId
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq "//unit.test/userroles/$testRoleId/predefined" -And `
                 $Method -eq 'Put'

--- a/Tests/Public/Set-TeamViewerRole.Tests.ps1
+++ b/Tests/Public/Set-TeamViewerRole.Tests.ps1
@@ -29,7 +29,7 @@ Describe 'Set-TeamViewerRole' {
     It 'Should call the correct API endpoint' {
         Set-TeamViewerRole -ApiToken $testApiToken -Name $testRoleName -RoleId $testRoleId
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/userroles' -And `
                 $Method -eq 'Put'

--- a/Tests/Public/Set-TeamViewerUser.Tests.ps1
+++ b/Tests/Public/Set-TeamViewerUser.Tests.ps1
@@ -25,7 +25,7 @@ Describe 'Set-TeamViewerUser' {
     It 'Should call the correct API endpoint' {
         Set-TeamViewerUser -ApiToken $testApiToken -User 'u1234' -Name 'Updated User Name'
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And $Uri -eq '//unit.test/users/u1234' -And $Method -eq 'Put' }
     }
 

--- a/Tests/Public/Set-TeamViewerUserGroup.Tests.ps1
+++ b/Tests/Public/Set-TeamViewerUserGroup.Tests.ps1
@@ -28,7 +28,7 @@ Describe 'Set-TeamViewerUserGroup' {
             -UserGroup $testUserGroupId `
             -Name $testUserGroupName
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
             $Uri -eq "//unit.test/usergroups/$testUserGroupId" -And `
             $Method -eq 'Put' }
@@ -41,7 +41,7 @@ Describe 'Set-TeamViewerUserGroup' {
             -UserGroup $testUserGroup `
             -Name $testUserGroupName
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
             $Uri -eq "//unit.test/usergroups/$testUserGroupId" -And `
             $Method -eq 'Put' }

--- a/Tests/Public/Start-TeamViewerService.Tests.ps1
+++ b/Tests/Public/Start-TeamViewerService.Tests.ps1
@@ -23,7 +23,7 @@ Describe 'Start-TeamViewerService' {
         }
         It 'Should start the TeamViewer Windows service' {
             Start-TeamViewerService | Out-Null
-            Assert-MockCalled Start-Service -Scope It -Times 1 -ParameterFilter {
+            Should -Invoke Start-Service -Scope It -Times 1 -ParameterFilter {
                 $Name -eq 'UnitTestTeamViewer'
             }
         }
@@ -35,7 +35,7 @@ Describe 'Start-TeamViewerService' {
         }
         It 'Should start the TeamViewer daemon' {
             Start-TeamViewerService | Out-Null
-            Assert-MockCalled Invoke-ExternalCommand -Scope It -Times 1 -ParameterFilter {
+            Should -Invoke Invoke-ExternalCommand -Scope It -Times 1 -ParameterFilter {
                 $Command -eq '/opt/teamviewer/tv_bin/script/teamviewer' -And
                 $CommandArgs[0] -eq 'daemon' -and $CommandArgs[1] -eq 'start'
             }

--- a/Tests/Public/Stop-TeamViewerService.Tests.ps1
+++ b/Tests/Public/Stop-TeamViewerService.Tests.ps1
@@ -23,7 +23,7 @@ Describe 'Stop-TeamViewerService' {
         }
         It 'Should stop the TeamViewer Windows service' {
             Stop-TeamViewerService | Out-Null
-            Assert-MockCalled Stop-Service -Scope It -Times 1 -ParameterFilter {
+            Should -Invoke Stop-Service -Scope It -Times 1 -ParameterFilter {
                 $Name -eq 'UnitTestTeamViewer'
             }
         }
@@ -35,7 +35,7 @@ Describe 'Stop-TeamViewerService' {
         }
         It 'Should stop the TeamViewer daemon' {
             Stop-TeamViewerService | Out-Null
-            Assert-MockCalled Invoke-ExternalCommand -Scope It -Times 1 -ParameterFilter {
+            Should -Invoke Invoke-ExternalCommand -Scope It -Times 1 -ParameterFilter {
                 $Command -eq '/opt/teamviewer/tv_bin/script/teamviewer' -And
                 $CommandArgs[0] -eq 'daemon' -and $CommandArgs[1] -eq 'stop'
             }

--- a/Tests/Public/Test-TeamViewerConnectivity.Tests.ps1
+++ b/Tests/Public/Test-TeamViewerConnectivity.Tests.ps1
@@ -12,13 +12,13 @@ Describe 'Test-TeamViewerConnectivity' {
     It 'Should check TCP connections to various endpoints' {
         Test-TeamViewerConnectivity
 
-        Assert-MockCalled Test-TcpConnection -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Test-TcpConnection -Times 1 -Scope It -ParameterFilter {
             $Hostname -eq 'webapi.teamviewer.com' -And $Port -eq 443
         }
-        Assert-MockCalled Test-TcpConnection -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Test-TcpConnection -Times 1 -Scope It -ParameterFilter {
             $Hostname -eq 'sso.teamviewer.com' -And $Port -eq 443
         }
-        Assert-MockCalled Test-TcpConnection -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Test-TcpConnection -Times 1 -Scope It -ParameterFilter {
             $Hostname -eq 'router1.teamviewer.com' -And $Port -eq 5938
         }
     }
@@ -30,13 +30,13 @@ Describe 'Test-TeamViewerConnectivity' {
 
         Test-TeamViewerConnectivity
 
-        Assert-MockCalled Test-TcpConnection -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Test-TcpConnection -Times 1 -Scope It -ParameterFilter {
             $Hostname -eq 'router1.teamviewer.com' -And $Port -eq 5938
         }
-        Assert-MockCalled Test-TcpConnection -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Test-TcpConnection -Times 1 -Scope It -ParameterFilter {
             $Hostname -eq 'router1.teamviewer.com' -And $Port -eq 443
         }
-        Assert-MockCalled Test-TcpConnection -Times 0 -Scope It -ParameterFilter {
+        Should -Invoke Test-TcpConnection -Times 0 -Scope It -ParameterFilter {
             $Hostname -eq 'router2.teamviewer.com' -And $Port -eq 443
         }
     }

--- a/Tests/Public/Unpublish-TeamViewerGroup.Tests.ps1
+++ b/Tests/Public/Unpublish-TeamViewerGroup.Tests.ps1
@@ -13,7 +13,7 @@ Describe 'Unpublish-TeamViewerGroup' {
     It 'Should call the correct API endpoint' {
         Unpublish-TeamViewerGroup -ApiToken $testApiToken -Group 'g1234' -User 'u1234'
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/groups/g1234/unshare_group' -And `
                 $Method -eq 'Post' }
@@ -36,7 +36,7 @@ Describe 'Unpublish-TeamViewerGroup' {
         $testGroup = @{ id = 'g1234'; name = 'test group' } | ConvertTo-TeamViewerGroup
         Unpublish-TeamViewerGroup -ApiToken $testApiToken -Group $testGroup -User 'u1234'
 
-        Assert-MockCalled Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -And `
                 $Uri -eq '//unit.test/groups/g1234/unshare_group' -And `
                 $Method -eq 'Post' }


### PR DESCRIPTION
Update all tests to support the changed assertion syntax for Pester 6.0.0 or later.