### PR TITLE
Set PowerShell as default Terminal profile in VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,6 +25,7 @@
     "powershell.codeFormatting.whitespaceBeforeOpenParen": true,
     "powershell.codeFormatting.whitespaceBetweenParameters": true,
     "powershell.codeFormatting.whitespaceInsideBrace": true,
+    "terminal.integrated.defaultProfile.windows": "PowerShell",
     "[markdown]": {
         "editor.tabSize": 2,
         "editor.trimAutoWhitespace": false,
@@ -48,5 +49,5 @@
     "cSpell.dictionaries": [
         "ProjectDictionary"
     ],
-    "cSpell.language": "en",
+    "cSpell.language": "en"
 }


### PR DESCRIPTION
## Summary
- Updates the VSCode terminal profile to use PowerShell per defaults.

## Changes
- Configures the default integrated terminal profile to PowerShell.

## Verification
- repository state was reviewed and branch pushed for PR creation.