### PR TITLE
Adds Company Management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 
 ### Added
 
-- Adds `Get-TeamViewerCompany` that returns the company / tenant details associated with the API token.
+- Adds `Get-TeamViewerCompany` to retrieve the company / tenant details.
+- Adds `Get-TeamViewerLicense` to retrieve company / tenant licenses.
+- Adds `Remove-TeamViewerCompany` to delete the company / tenant (Dangerous!).
+- Adds `Set-TeamViewerCompany` to modify the company / tenant details.
 
 ## 2.6.0 (2026-07-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Adds `Get-TeamViewerCompany` to retrieve the company / tenant details.
 - Adds `Get-TeamViewerLicense` to retrieve company / tenant licenses.
-- Adds `Remove-TeamViewerCompany` to delete the company / tenant (Dangerous!).
+- Adds `Remove-TeamViewerCompany` to delete the company / tenant (Cannot be reverted, use with care!).
 - Adds `Set-TeamViewerCompany` to modify the company / tenant details.
 
 ## 2.6.0 (2026-07-30)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## x.x.x (2026-xx-xx)
+
+### Added
+
+- Adds `Get-TeamViewerCompany` that returns the company / tenant details associated with the API token.
+
 ## 2.6.0 (2026-07-30)
 
 ### Updated

--- a/Cmdlets/Private/ConvertTo-TeamViewerCompany.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerCompany.ps1
@@ -1,0 +1,21 @@
+function ConvertTo-TeamViewerCompany {
+    param(
+        [Parameter(ValueFromPipeline)]
+        [PSObject]
+        $InputObject
+    )
+    process {
+        $properties = @{
+            CompanyId   = [int]$InputObject.companyId
+            CompanyName = $InputObject.companyName
+        }
+
+        $result = New-Object -TypeName PSObject -Property $properties
+        $result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.Company')
+        $result | Add-Member -MemberType ScriptMethod -Name 'ToString' -Force -Value {
+            Write-Output "$($this.CompanyName)"
+        }
+
+        Write-Output $result
+    }
+}

--- a/Cmdlets/Private/ConvertTo-TeamViewerLicense.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerLicense.ps1
@@ -1,0 +1,23 @@
+function ConvertTo-TeamViewerLicense {
+    param(
+        [Parameter(ValueFromPipeline)]
+        [PSObject]
+        $InputObject
+    )
+
+    process {
+        $properties = @{
+            CompanyId         = [int]$InputObject.companyId
+            CompanyName       = $InputObject.companyName
+            AvailableLicenses = @($InputObject.available_licenses | ConvertTo-TeamViewerLicenseInformation)
+        }
+
+        $result = New-Object -TypeName PSObject -Property $properties
+        $result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.License')
+        $result | Add-Member -MemberType ScriptMethod -Name 'ToString' -Force -Value {
+            Write-Output "$($this.CompanyName)"
+        }
+
+        Write-Output $result
+    }
+}

--- a/Cmdlets/Private/ConvertTo-TeamViewerLicenseInformation.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerLicenseInformation.ps1
@@ -1,0 +1,33 @@
+function ConvertTo-TeamViewerLicenseInformation {
+    param(
+        [Parameter(ValueFromPipeline)]
+        [PSObject]
+        $InputObject
+    )
+
+    process {
+        $properties = @{
+            LicenseName      = $InputObject.licenseName
+            Version          = [int]$InputObject.version
+            Type             = $InputObject.type
+            LicenseId        = [guid]$InputObject.licenseId
+            IsActive         = [bool]$InputObject.isActive
+            AiCredits        = [int]$InputObject.aiCredits
+            ManagedDevices   = [int]$InputObject.managedDevices
+            AssignedUsers    = [int]$InputObject.assignedUsers
+            DisplayName      = $InputObject.displayName
+            Details          = $InputObject.details
+            NumberOfChannels = [int]$InputObject.numberOfChannels
+            MaxAssignments   = [int]$InputObject.maxAssignments
+            TotalTechnicians = [int]$InputObject.totalTechnicians
+        }
+
+        $result = New-Object -TypeName PSObject -Property $properties
+        $result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.LicenseInformation')
+        $result | Add-Member -MemberType ScriptMethod -Name 'ToString' -Force -Value {
+            Write-Output "$($this.LicenseName)"
+        }
+
+        Write-Output $result
+    }
+}

--- a/Cmdlets/Public/Get-TeamViewerCompany.ps1
+++ b/Cmdlets/Public/Get-TeamViewerCompany.ps1
@@ -1,0 +1,18 @@
+function Get-TeamViewerCompany {
+    param(
+        [Parameter(Mandatory = $true)]
+        [securestring]
+        $ApiToken
+    )
+
+    $resourceUri = "$(Get-TeamViewerApiUri)/company"
+
+    $response = Invoke-TeamViewerRestMethod `
+        -ApiToken $ApiToken `
+        -Uri $resourceUri `
+        -Method Get `
+        -WriteErrorTo $PSCmdlet `
+        -ErrorAction Stop
+
+    Write-Output ($response | ConvertTo-TeamViewerCompany)
+}

--- a/Cmdlets/Public/Get-TeamViewerLicense.ps1
+++ b/Cmdlets/Public/Get-TeamViewerLicense.ps1
@@ -1,0 +1,18 @@
+function Get-TeamViewerLicense {
+    param(
+        [Parameter(Mandatory = $true)]
+        [securestring]
+        $ApiToken
+    )
+
+    $resourceUri = "$(Get-TeamViewerApiUri)/company/license"
+
+    $response = Invoke-TeamViewerRestMethod `
+        -ApiToken $ApiToken `
+        -Uri $resourceUri `
+        -Method Get `
+        -WriteErrorTo $PSCmdlet `
+        -ErrorAction Stop
+
+    Write-Output ($response | ConvertTo-TeamViewerLicense)
+}

--- a/Cmdlets/Public/Remove-TeamViewerCompany.ps1
+++ b/Cmdlets/Public/Remove-TeamViewerCompany.ps1
@@ -1,0 +1,19 @@
+function Remove-TeamViewerCompany {
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param(
+        [Parameter(Mandatory = $true)]
+        [securestring]
+        $ApiToken
+    )
+
+    $resourceUri = "$(Get-TeamViewerApiUri)/company"
+
+    if ($PSCmdlet.ShouldProcess('TeamViewer company', 'Delete company')) {
+        Invoke-TeamViewerRestMethod `
+            -ApiToken $ApiToken `
+            -Uri $resourceUri `
+            -Method Delete `
+            -WriteErrorTo $PSCmdlet | `
+            Out-Null
+    }
+}

--- a/Cmdlets/Public/Set-TeamViewerCompany.ps1
+++ b/Cmdlets/Public/Set-TeamViewerCompany.ps1
@@ -1,0 +1,48 @@
+function Set-TeamViewerCompany {
+    [CmdletBinding(SupportsShouldProcess = $true, DefaultParameterSetName = 'ByParameters')]
+    param(
+        [Parameter(Mandatory = $true)]
+        [securestring]
+        $ApiToken,
+
+        [Parameter(ParameterSetName = 'ByParameters')]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'ByProperties')]
+        [hashtable]
+        $Property
+    )
+
+    $null = $Property
+
+    $body = @{}
+    switch ($PSCmdlet.ParameterSetName) {
+        'ByParameters' {
+            if ($Name) {
+                $body['name'] = $Name
+            }
+        }
+        'ByProperties' {
+            @('name') | Where-Object { $Property[$_] } | ForEach-Object { $body[$_] = $Property[$_] }
+        }
+    }
+
+    if ($body.Count -eq 0) {
+        $PSCmdlet.ThrowTerminatingError(
+            ('The given input does not change the company.' | ConvertTo-ErrorRecord -ErrorCategory InvalidArgument))
+    }
+
+    $resourceUri = "$(Get-TeamViewerApiUri)/company"
+
+    if ($PSCmdlet.ShouldProcess('TeamViewer company')) {
+        Invoke-TeamViewerRestMethod `
+            -ApiToken $ApiToken `
+            -Uri $resourceUri `
+            -Method Put `
+            -ContentType 'application/json; charset=utf-8' `
+            -Body ([System.Text.Encoding]::UTF8.GetBytes(($body | ConvertTo-Json))) `
+            -WriteErrorTo $PSCmdlet | `
+            Out-Null
+    }
+}

--- a/Docs/Help/Get-TeamViewerCompany.md
+++ b/Docs/Help/Get-TeamViewerCompany.md
@@ -1,0 +1,66 @@
+---
+external help file: TeamViewerPS-help.xml
+Module Name: TeamViewerPS
+online version: https://github.com/teamviewer/TeamViewerPS/blob/main/Docs/Help/Get-TeamViewerCompany.md
+schema: 2.0.0
+---
+
+# Get-TeamViewerCompany
+
+## SYNOPSIS
+
+Retrieves company / tenant details of the TeamViewer company associated with the API token.
+
+## SYNTAX
+
+```powershell
+Get-TeamViewerCompany [-ApiToken] <SecureString> [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+Retrieves the company / tenant details of the TeamViewer company associated with the TeamViewer API access token.
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+PS /> $company = Get-TeamViewerCompany
+```
+
+Retrieve the company details and store the result in a variable.
+
+## PARAMETERS
+
+### -ApiToken
+
+The TeamViewer API access token.
+
+```yaml
+Type: SecureString
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### TeamViewerPS.Company
+
+## NOTES
+
+## RELATED LINKS

--- a/Docs/Help/Get-TeamViewerLicense.md
+++ b/Docs/Help/Get-TeamViewerLicense.md
@@ -1,0 +1,67 @@
+---
+external help file: TeamViewerPS-help.xml
+Module Name: TeamViewerPS
+online version: https://github.com/teamviewer/TeamViewerPS/blob/main/Docs/Help/Get-TeamViewerLicense.md
+schema: 2.0.0
+---
+
+# Get-TeamViewerLicense
+
+## SYNOPSIS
+
+Retrieves company / tenant license details of the TeamViewer company associated with the API token.
+
+## SYNTAX
+
+```powershell
+Get-TeamViewerLicense [-ApiToken] <SecureString> [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+Retrieves the company license details of the TeamViewer company associated with the
+TeamViewer API access token.
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+PS /> $license = Get-TeamViewerLicense
+```
+
+Retrieve the company license details and store the result in a variable.
+
+## PARAMETERS
+
+### -ApiToken
+
+The TeamViewer API access token.
+
+```yaml
+Type: SecureString
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningWarning. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### TeamViewerPS.License
+
+## NOTES
+
+## RELATED LINKS

--- a/Docs/Help/Remove-TeamViewerCompany.md
+++ b/Docs/Help/Remove-TeamViewerCompany.md
@@ -1,0 +1,97 @@
+---
+external help file: TeamViewerPS-help.xml
+Module Name: TeamViewerPS
+online version: https://github.com/teamviewer/TeamViewerPS/blob/main/Docs/Help/Remove-TeamViewerCompany.md
+schema: 2.0.0
+---
+
+# Remove-TeamViewerCompany
+
+## SYNOPSIS
+
+Delete the TeamViewer company / tenant associated with the API token.
+
+## SYNTAX
+
+```powershell
+Remove-TeamViewerCompany [-ApiToken] <SecureString> [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+Deletes the TeamViewer company associated with the TeamViewer API access token.
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+PS /> Remove-TeamViewerCompany
+```
+
+Delete the company associated with the API token.
+
+## PARAMETERS
+
+### -ApiToken
+
+The TeamViewer API access token.
+
+```yaml
+Type: SecureString
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS

--- a/Docs/Help/Remove-TeamViewerCompany.md
+++ b/Docs/Help/Remove-TeamViewerCompany.md
@@ -10,6 +10,7 @@ schema: 2.0.0
 ## SYNOPSIS
 
 Delete the TeamViewer company / tenant associated with the API token.
+The action cannot be reverted, use with care!
 
 ## SYNTAX
 
@@ -20,6 +21,8 @@ Remove-TeamViewerCompany [-ApiToken] <SecureString> [-WhatIf] [-Confirm] [<Commo
 ## DESCRIPTION
 
 Deletes the TeamViewer company associated with the TeamViewer API access token.
+The account should be the last user with admin permissions in the company / tenant.
+The action cannot be reverted, use with care!
 
 ## EXAMPLES
 

--- a/Docs/Help/Set-TeamViewerCompany.md
+++ b/Docs/Help/Set-TeamViewerCompany.md
@@ -1,0 +1,140 @@
+---
+external help file: TeamViewerPS-help.xml
+Module Name: TeamViewerPS
+online version: https://github.com/teamviewer/TeamViewerPS/blob/main/Docs/Help/Set-TeamViewerCompany.md
+schema: 2.0.0
+---
+
+# Set-TeamViewerCompany
+
+## SYNOPSIS
+
+Change TeamViewer company / tenant details.
+
+## SYNTAX
+
+### ByParameters (Default)
+
+```powershell
+Set-TeamViewerCompany -ApiToken <SecureString> [-Name <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+### ByProperties
+
+```powershell
+Set-TeamViewerCompany -ApiToken <SecureString> -Property <Hashtable> [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+Changes company details of the TeamViewer company associated with the API
+access token.
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+PS /> Set-TeamViewerCompany -Name 'TeamViewer Germany GmbH'
+```
+
+Change the company name.
+
+## PARAMETERS
+
+### -ApiToken
+
+The TeamViewer API access token.
+
+```yaml
+Type: SecureString
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Name
+
+Updated name of the company.
+
+```yaml
+Type: String
+Parameter Sets: ByParameters
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Property
+
+Change company information using a hashtable object.
+Valid hashtable keys are:
+`name`
+
+```yaml
+Type: Hashtable
+Parameter Sets: ByProperties
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS

--- a/Docs/TeamViewerPS.md
+++ b/Docs/TeamViewerPS.md
@@ -34,6 +34,12 @@ Manage company / tenant details for the TeamViewer company associated with the A
 
 [`Get-TeamViewerCompany`](Help/Get-TeamViewerCompany.md)
 
+[`Get-TeamViewerLicense`](Help/Get-TeamViewerLicense.md)
+
+[`Remove-TeamViewerCompany`](Help/Remove-TeamViewerCompany.md)
+
+[`Set-TeamViewerCompany`](Help/Set-TeamViewerCompany.md)
+
 ## Computers & Contacts
 
 Remotely manage the Computers & Contacts via the TeamViewer Web API.

--- a/Docs/TeamViewerPS.md
+++ b/Docs/TeamViewerPS.md
@@ -28,6 +28,12 @@ Manage customization of the locally installed TeamViewer Client.
 
 [`Remove-TeamViewerCustomization`](Help/Remove-TeamViewerCustomization.md)
 
+## Company Management
+
+Manage company / tenant details for the TeamViewer company associated with the API token.
+
+[`Get-TeamViewerCompany`](Help/Get-TeamViewerCompany.md)
+
 ## Computers & Contacts
 
 Remotely manage the Computers & Contacts via the TeamViewer Web API.

--- a/Tests/Public/Get-TeamViewerCompany.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerCompany.Tests.ps1
@@ -1,0 +1,37 @@
+BeforeAll {
+    . "$PSScriptRoot\..\..\Cmdlets\Public\Get-TeamViewerCompany.ps1"
+
+    @(Get-ChildItem -Path "$PSScriptRoot\..\..\Cmdlets\Private\*.ps1") | `
+        ForEach-Object { . $_.FullName }
+
+    $testApiToken = [securestring]@{}
+    $null = $testApiToken
+
+    Mock Get-TeamViewerApiUri { '//unit.test' }
+    Mock Invoke-TeamViewerRestMethod {
+        @{
+            companyId   = 42
+            companyName = 'TeamViewer Germany GmbH'
+        }
+    }
+}
+
+Describe 'Get-TeamViewerCompany' {
+    It 'Should call the correct API endpoint' {
+        Get-TeamViewerCompany -ApiToken $testApiToken
+
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+            $ApiToken -eq $testApiToken -and `
+                $Uri -eq '//unit.test/company' -and `
+                $Method -eq 'Get' }
+    }
+
+    It 'Should return Company object' {
+        $result = Get-TeamViewerCompany -ApiToken $testApiToken
+        $result | Should -Not -BeNullOrEmpty
+        $result.PSObject.TypeNames | Should -Contain 'TeamViewerPS.Company'
+        $result.CompanyId | Should -Be 42
+        $result.CompanyName | Should -Be 'TeamViewer Germany GmbH'
+        $result.ToString() | Should -Be 'TeamViewer Germany GmbH'
+    }
+}

--- a/Tests/Public/Get-TeamViewerLicense.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerLicense.Tests.ps1
@@ -1,0 +1,57 @@
+BeforeAll {
+    . "$PSScriptRoot\..\..\Cmdlets\Public\Get-TeamViewerLicense.ps1"
+
+    @(Get-ChildItem -Path "$PSScriptRoot\..\..\Cmdlets\Private\*.ps1") | `
+        ForEach-Object { . $_.FullName }
+
+    $testApiToken = [securestring]@{}
+    $null = $testApiToken
+
+    Mock Get-TeamViewerApiUri { '//unit.test' }
+    Mock Invoke-TeamViewerRestMethod {
+        @{
+            companyId          = 42
+            companyName        = 'TeamViewer Germany GmbH'
+            available_licenses = @(
+                @{
+                    licenseName      = 'Tensor'
+                    version          = 1
+                    type             = 'subscription'
+                    licenseId        = '00000000-0000-0000-0000-000000000001'
+                    isActive         = $true
+                    aiCredits        = 10
+                    managedDevices   = 5
+                    assignedUsers    = 2
+                    displayName      = 'Tensor'
+                    details          = 'Main license'
+                    numberOfChannels = 3
+                    maxAssignments   = 5
+                    totalTechnicians = 2
+                }
+            )
+        }
+    }
+}
+
+Describe 'Get-TeamViewerLicense' {
+    It 'Should call the correct API endpoint' {
+        Get-TeamViewerLicense -ApiToken $testApiToken
+
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+            $ApiToken -eq $testApiToken -and `
+                $Uri -eq '//unit.test/company/license' -and `
+                $Method -eq 'Get' }
+    }
+
+    It 'Should return License object' {
+        $result = Get-TeamViewerLicense -ApiToken $testApiToken
+        $result | Should -Not -BeNullOrEmpty
+        $result.PSObject.TypeNames | Should -Contain 'TeamViewerPS.License'
+        $result.CompanyId | Should -Be 42
+        $result.CompanyName | Should -Be 'TeamViewer Germany GmbH'
+        $result.AvailableLicenses | Should -HaveCount 1
+        $result.AvailableLicenses[0].PSObject.TypeNames | Should -Contain 'TeamViewerPS.LicenseInformation'
+        $result.AvailableLicenses[0].LicenseName | Should -Be 'Tensor'
+        $result.ToString() | Should -Be 'TeamViewer Germany GmbH'
+    }
+}

--- a/Tests/Public/Remove-TeamViewerCompany.Tests.ps1
+++ b/Tests/Public/Remove-TeamViewerCompany.Tests.ps1
@@ -1,0 +1,23 @@
+BeforeAll {
+    . "$PSScriptRoot\..\..\Cmdlets\Public\Remove-TeamViewerCompany.ps1"
+
+    @(Get-ChildItem -Path "$PSScriptRoot\..\..\Cmdlets\Private\*.ps1") | `
+        ForEach-Object { . $_.FullName }
+
+    $testApiToken = [securestring]@{}
+    $null = $testApiToken
+
+    Mock Get-TeamViewerApiUri { '//unit.test' }
+    Mock Invoke-TeamViewerRestMethod {}
+}
+
+Describe 'Remove-TeamViewerCompany' {
+    It 'Should call the correct API endpoint' {
+        Remove-TeamViewerCompany -ApiToken $testApiToken
+
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+            $ApiToken -eq $testApiToken -and `
+                $Uri -eq '//unit.test/company' -and `
+                $Method -eq 'Delete' }
+    }
+}

--- a/Tests/Public/Set-TeamViewerCompany.Tests.ps1
+++ b/Tests/Public/Set-TeamViewerCompany.Tests.ps1
@@ -1,0 +1,44 @@
+BeforeAll {
+    . "$PSScriptRoot\..\..\Cmdlets\Public\Set-TeamViewerCompany.ps1"
+
+    @(Get-ChildItem -Path "$PSScriptRoot\..\..\Cmdlets\Private\*.ps1") | `
+        ForEach-Object { . $_.FullName }
+
+    $testApiToken = [securestring]@{}
+    $null = $testApiToken
+    $mockArgs = @{}
+
+    Mock Get-TeamViewerApiUri { '//unit.test' }
+    Mock Invoke-TeamViewerRestMethod { $mockArgs.Body = $Body }
+}
+
+Describe 'Set-TeamViewerCompany' {
+    It 'Should call the correct API endpoint' {
+        Set-TeamViewerCompany -ApiToken $testApiToken -Name 'Updated TeamViewer Germany GmbH'
+
+        Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
+            $ApiToken -eq $testApiToken -and `
+                $Uri -eq '//unit.test/company' -and `
+                $Method -eq 'Put' }
+    }
+
+    It 'Should change company name' {
+        Set-TeamViewerCompany -ApiToken $testApiToken -Name 'Updated TeamViewer Germany GmbH'
+
+        $mockArgs.Body | Should -Not -BeNullOrEmpty
+        $body = [System.Text.Encoding]::UTF8.GetString($mockArgs.Body) | ConvertFrom-Json
+        $body.name | Should -Be 'Updated TeamViewer Germany GmbH'
+    }
+
+    It 'Should accept changes as hashtable' {
+        Set-TeamViewerCompany -ApiToken $testApiToken -Property @{ name = 'Updated TeamViewer Germany GmbH' }
+
+        $mockArgs.Body | Should -Not -BeNullOrEmpty
+        $body = [System.Text.Encoding]::UTF8.GetString($mockArgs.Body) | ConvertFrom-Json
+        $body.name | Should -Be 'Updated TeamViewer Germany GmbH'
+    }
+
+    It 'Should throw if input does not contain any valid change' {
+        { Set-TeamViewerCompany -ApiToken $testApiToken } | Should -Throw
+    }
+}


### PR DESCRIPTION
Summary:
- Adds `Get-TeamViewerCompany` for the Company Management GET `/api/v1/company` endpoint.
- Introduces `ConvertTo-TeamViewerCompany` with a typed `TeamViewerPS.Company` output object.
- Adds Pester coverage for the API call and returned object shape.
- Documents the new cmdlet in `Docs/Help` and the module overview.

Notes:
- The implementation follows the existing REST cmdlet pattern used elsewhere in the module.