### PR TITLE
Adds Get-TeamViewerInstallationPackage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Adds `Get-TeamViewerInstallationPackage` that returns the installed TV package (Full or Host) from locally installed TV client.
 - Adds `Get-TeamViewerCompany` to retrieve the company / tenant details.
 - Adds `Get-TeamViewerLicense` to retrieve company / tenant licenses.
 - Adds `Remove-TeamViewerCompany` to delete the company / tenant (Cannot be reverted, use with care!).

--- a/Cmdlets/Public/Get-TeamViewerInstallationPackage.ps1
+++ b/Cmdlets/Public/Get-TeamViewerInstallationPackage.ps1
@@ -1,0 +1,20 @@
+function Get-TeamViewerInstallationPackage {
+    if (Test-TeamViewerInstallation) {
+        $Package = (Get-Item -Path (Join-Path -Path $TV_InstallationDirectory -ChildPath 'TeamViewer.exe')).VersionInfo.ProductName
+
+        switch -Wildcard ($Package) {
+            '*Full*' {
+                return 'Full'
+            }
+            '*Host*' {
+                return 'Host'
+            }
+            default {
+                return $null
+            }
+        }
+    }
+    else {
+        return $null
+    }
+}

--- a/Docs/Help/Get-TeamViewerInstallationPackage.md
+++ b/Docs/Help/Get-TeamViewerInstallationPackage.md
@@ -1,0 +1,57 @@
+---
+external help file: TeamViewerPS-help.xml
+Module Name: TeamViewerPS
+online version: https://github.com/teamviewer/TeamViewerPS/blob/main/Docs/Help/Get-TeamViewerInstallationPackage.md
+schema: 2.0.0
+---
+
+# Get-TeamViewerInstallationPackage
+
+## SYNOPSIS
+
+Returns the installed TeamViewer package type (Full or Host).
+
+## SYNTAX
+
+```powershell
+Get-TeamViewerInstallationPackage [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+The command checks the installed TeamViewer executable and returns the package type based on the file metadata.
+It returns `Full` for full client installations, `Host` for host installations, or nothing if the package type cannot be determined.
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+PS /> Get-TeamViewerInstallationPackage
+```
+
+Returns `Full` or `Host` depending on the installed TeamViewer package.
+
+## PARAMETERS
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.String
+
+Returns `Full`, `Host`, or `$null` when the package type cannot be determined.
+
+## NOTES
+
+## RELATED LINKS
+
+[Get-TeamViewerInstallationDirectory](Get-TeamViewerInstallationDirectory.md)
+
+[Test-TeamViewerInstallation](Test-TeamViewerInstallation.md)

--- a/Docs/TeamViewerPS.md
+++ b/Docs/TeamViewerPS.md
@@ -227,6 +227,8 @@ Utilities that help managing the local TeamViewer client.
 
 [`Get-TeamViewerInstallationDirectory`](Help/Get-TeamViewerInstallationDirectory.md)
 
+[`Get-TeamViewerInstallationPackage`](Help/Get-TeamViewerInstallationPackage.md)
+
 [`Get-TeamViewerInstallationType`](Help/Get-TeamViewerInstallationType.md)
 
 [`Get-TeamViewerLogFilePath`](Help/Get-TeamViewerLogFilePath.md)

--- a/Tests/Public/Get-TeamViewerInstallationPackage.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerInstallationPackage.Tests.ps1
@@ -1,0 +1,62 @@
+BeforeAll {
+    . "$PSScriptRoot\..\..\Cmdlets\Public\Get-TeamViewerInstallationPackage.ps1"
+    . "$PSScriptRoot\..\..\Cmdlets\Public\Test-TeamViewerInstallation.ps1"
+    @(Get-ChildItem -Path "$PSScriptRoot\..\..\Cmdlets\Private\*.ps1") | ForEach-Object { . $_.FullName }
+}
+
+Describe 'Get-TeamViewerInstallationPackage' {
+    BeforeAll {
+        Mock Test-TeamViewerInstallation { $true }
+        $script:TV_InstallationDirectory = 'testPath'
+
+        $script:testVersionInfo = [PSCustomObject]@{
+            ProductName = $null
+        }
+
+        $script:testItem = [PSCustomObject]@{}
+        $script:testItem | Add-Member `
+            -MemberType NoteProperty `
+            -Name VersionInfo `
+            -Value $script:testVersionInfo
+
+        Mock Get-Item -ParameterFilter {
+            $Path -eq (Join-Path -Path 'testPath' -ChildPath 'TeamViewer.exe')
+        } { $script:testItem }
+    }
+
+    It 'Should map the TeamViewer ProductName to a package type' -TestCases @(
+        @{ ProductName = 'TeamViewer Full Client'; Expected = 'Full' }
+        @{ ProductName = 'TeamViewer Host Client'; Expected = 'Host' }
+        @{ ProductName = 'TeamViewer Something'; Expected = $null }
+        @{ ProductName = $null; Expected = $null }
+    ) {
+        param(
+            [object]$ProductName,
+            [object]$Expected
+        )
+
+        $script:testVersionInfo.ProductName = $ProductName
+
+        $result = Get-TeamViewerInstallationPackage
+
+        if ($null -eq $Expected) {
+            $result | Should -BeNullOrEmpty
+        }
+        else {
+            $result | Should -Be $Expected
+        }
+
+        Should -Invoke Test-TeamViewerInstallation -Scope It -Times 1
+        Should -Invoke Get-Item -Scope It -Times 1 -ParameterFilter {
+            $Path -eq (Join-Path -Path 'testPath' -ChildPath 'TeamViewer.exe')
+        }
+    }
+
+    It 'Should return null when TeamViewer is not installed' {
+        Mock Test-TeamViewerInstallation { $false }
+
+        Get-TeamViewerInstallationPackage | Should -BeNullOrEmpty
+
+        Should -Invoke Get-Item -Scope It -Times 0
+    }
+}


### PR DESCRIPTION
## Summary
- add `Get-TeamViewerInstallationPackage` to return the TeamViewer package type from the executable metadata
- document the cmdlet in `Docs/Help` and add it to the local client utilities index
- add Pester coverage for Full, Host, null/default, and not-installed cases

## Validation
- `Invoke-Pester -Path Tests/Public/Get-TeamViewerInstallationPackage.Tests.ps1`