### PR TITLE
Harmonize private ConvertTo functions

### DIFF
--- a/Cmdlets/Private/ConvertTo-ErrorRecord.ps1
+++ b/Cmdlets/Private/ConvertTo-ErrorRecord.ps1
@@ -9,7 +9,7 @@ function ConvertTo-ErrorRecord {
         $ErrorCategory = [System.Management.Automation.ErrorCategory]::NotSpecified
     )
 
-    begin {
+    process {
         $category = $ErrorCategory
         $message = $InputObject.ToString()
         $errorId = 'TeamViewerError'
@@ -53,9 +53,7 @@ function ConvertTo-ErrorRecord {
 
             $errorId = 'TeamViewerRestError'
         }
-    }
 
-    process {
         $exception = [System.Management.Automation.RuntimeException]($message)
         $errorRecord = New-Object System.Management.Automation.ErrorRecord $exception, $errorId, $category, $null
         $errorRecord.ErrorDetails = $message

--- a/Cmdlets/Private/ConvertTo-ErrorRecord.ps1
+++ b/Cmdlets/Private/ConvertTo-ErrorRecord.ps1
@@ -9,7 +9,7 @@ function ConvertTo-ErrorRecord {
         $ErrorCategory = [System.Management.Automation.ErrorCategory]::NotSpecified
     )
 
-    process {
+    begin {
         $category = $ErrorCategory
         $message = $InputObject.ToString()
         $errorId = 'TeamViewerError'
@@ -53,7 +53,9 @@ function ConvertTo-ErrorRecord {
 
             $errorId = 'TeamViewerRestError'
         }
+    }
 
+    process {
         $exception = [System.Management.Automation.RuntimeException]($message)
         $errorRecord = New-Object System.Management.Automation.ErrorRecord $exception, $errorId, $category, $null
         $errorRecord.ErrorDetails = $message

--- a/Cmdlets/Private/ConvertTo-TeamViewerAccount.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerAccount.ps1
@@ -4,6 +4,7 @@ function ConvertTo-TeamViewerAccount {
         [PSObject]
         $InputObject
     )
+
     process {
         $properties = @{
             Name             = $InputObject.name
@@ -13,14 +14,17 @@ function ConvertTo-TeamViewerAccount {
             IsEmailValidated = $InputObject.email_validated
             EmailLanguage    = $InputObject.email_language
         }
-        if ($InputObject.email_language -And $InputObject.email_language -Ne 'auto') {
-            $properties["EmailLanguage"] = [System.Globalization.CultureInfo]($InputObject.email_language)
+
+        if ($InputObject.email_language -and $InputObject.email_language -ne 'auto') {
+            $properties['EmailLanguage'] = [System.Globalization.CultureInfo]($InputObject.email_language)
         }
+
         $result = New-Object -TypeName PSObject -Property $properties
         $result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.Account')
-        $result | Add-Member -MemberType ScriptMethod -Name "ToString" -Force -Value {
-            Write-Output "$($this.Name) <$($this.Email)>"
+        $result | Add-Member -MemberType ScriptMethod -Name 'ToString' -Force -Value {
+            "$($this.Name) <$($this.Email)>"
         }
-        Write-Output $result
+
+        $result
     }
 }

--- a/Cmdlets/Private/ConvertTo-TeamViewerAuditEvent.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerAuditEvent.ps1
@@ -4,6 +4,7 @@ function ConvertTo-TeamViewerAuditEvent {
         [PSObject]
         $InputObject
     )
+
     process {
         $properties = @{
             Name         = $InputObject.EventName
@@ -13,11 +14,13 @@ function ConvertTo-TeamViewerAuditEvent {
             AffectedItem = $InputObject.AffectedItem
             EventDetails = $InputObject.EventDetails
         }
+
         $result = New-Object -TypeName PSObject -Property $properties
         $result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.AuditEvent')
-        $result | Add-Member -MemberType ScriptMethod -Name "ToString" -Force -Value {
-            Write-Output "[$($this.Timestamp)] $($this.Name) ($($this.Type))"
+        $result | Add-Member -MemberType ScriptMethod -Name 'ToString' -Force -Value {
+            "[$($this.Timestamp)] $($this.Name) ($($this.Type))"
         }
-        Write-Output $result
+
+        $result
     }
 }

--- a/Cmdlets/Private/ConvertTo-TeamViewerCompany.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerCompany.ps1
@@ -9,6 +9,11 @@ function ConvertTo-TeamViewerCompany {
         $properties = @{
             CompanyId   = [int]$InputObject.companyId
             CompanyName = $InputObject.companyName
+            CreatedAt   = $null
+        }
+
+        if ($InputObject.createdAt) {
+            $properties['CreatedAt'] = $InputObject.createdAt | ConvertTo-DateTime
         }
 
         $result = New-Object -TypeName PSObject -Property $properties

--- a/Cmdlets/Private/ConvertTo-TeamViewerCompany.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerCompany.ps1
@@ -5,14 +5,12 @@ function ConvertTo-TeamViewerCompany {
         $InputObject
     )
 
-    begin {
+    process {
         $properties = @{
             CompanyId   = [int]$InputObject.companyId
             CompanyName = $InputObject.companyName
         }
-    }
 
-    process {
         $result = New-Object -TypeName PSObject -Property $properties
         $result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.Company')
         $result | Add-Member -MemberType ScriptMethod -Name 'ToString' -Force -Value {

--- a/Cmdlets/Private/ConvertTo-TeamViewerCompany.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerCompany.ps1
@@ -4,18 +4,21 @@ function ConvertTo-TeamViewerCompany {
         [PSObject]
         $InputObject
     )
-    process {
+
+    begin {
         $properties = @{
             CompanyId   = [int]$InputObject.companyId
             CompanyName = $InputObject.companyName
         }
+    }
 
+    process {
         $result = New-Object -TypeName PSObject -Property $properties
         $result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.Company')
         $result | Add-Member -MemberType ScriptMethod -Name 'ToString' -Force -Value {
-            Write-Output "$($this.CompanyName)"
+            "$($this.CompanyName)"
         }
 
-        Write-Output $result
+        $result
     }
 }

--- a/Cmdlets/Private/ConvertTo-TeamViewerConnectionReport.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerConnectionReport.ps1
@@ -4,7 +4,8 @@ function ConvertTo-TeamViewerConnectionReport {
         [PSObject]
         $InputObject
     )
-    process {
+
+    begin {
         $properties = @{
             Id                 = $InputObject.id
             UserId             = $InputObject.userid
@@ -22,9 +23,12 @@ function ConvertTo-TeamViewerConnectionReport {
             Currency           = $InputObject.currency
             Notes              = $InputObject.notes
         }
+    }
 
+    process {
         $result = New-Object -TypeName PSObject -Property $properties
         $result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.ConnectionReport')
-        Write-Output $result
+
+        $result
     }
 }

--- a/Cmdlets/Private/ConvertTo-TeamViewerConnectionReport.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerConnectionReport.ps1
@@ -5,7 +5,7 @@ function ConvertTo-TeamViewerConnectionReport {
         $InputObject
     )
 
-    begin {
+    process {
         $properties = @{
             Id                 = $InputObject.id
             UserId             = $InputObject.userid
@@ -23,9 +23,7 @@ function ConvertTo-TeamViewerConnectionReport {
             Currency           = $InputObject.currency
             Notes              = $InputObject.notes
         }
-    }
 
-    process {
         $result = New-Object -TypeName PSObject -Property $properties
         $result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.ConnectionReport')
 

--- a/Cmdlets/Private/ConvertTo-TeamViewerContact.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerContact.ps1
@@ -4,22 +4,26 @@ function ConvertTo-TeamViewerContact {
         [PSObject]
         $InputObject
     )
-    process {
+
+    begin {
         $properties = @{
-            Id                = $InputObject.contact_id
-            UserId            = $InputObject.user_id
-            GroupId           = $InputObject.groupid
+            Id                = [int]$InputObject.contact_id
+            UserId            = [int]$InputObject.user_id
+            GroupId           = [int]$InputObject.groupid
             Name              = $InputObject.name
             Description       = $InputObject.description
             OnlineState       = $InputObject.online_state
             ProfilePictureUrl = $InputObject.profilepicture_url
             SupportedFeatures = $InputObject.supported_features
         }
+    }
+    process {
         $result = New-Object -TypeName PSObject -Property $properties
         $result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.Contact')
-        $result | Add-Member -MemberType ScriptMethod -Name "ToString" -Force -Value {
-            Write-Output "$($this.Name)"
+        $result | Add-Member -MemberType ScriptMethod -Name 'ToString' -Force -Value {
+            "$($this.Name)"
         }
-        Write-Output $result
+
+        $result
     }
 }

--- a/Cmdlets/Private/ConvertTo-TeamViewerContact.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerContact.ps1
@@ -5,19 +5,18 @@ function ConvertTo-TeamViewerContact {
         $InputObject
     )
 
-    begin {
+    process {
         $properties = @{
-            Id                = [int]$InputObject.contact_id
-            UserId            = [int]$InputObject.user_id
-            GroupId           = [int]$InputObject.groupid
+            Id                = $InputObject.contact_id
+            UserId            = $InputObject.user_id
+            GroupId           = $InputObject.groupid
             Name              = $InputObject.name
             Description       = $InputObject.description
             OnlineState       = $InputObject.online_state
             ProfilePictureUrl = $InputObject.profilepicture_url
             SupportedFeatures = $InputObject.supported_features
         }
-    }
-    process {
+
         $result = New-Object -TypeName PSObject -Property $properties
         $result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.Contact')
         $result | Add-Member -MemberType ScriptMethod -Name 'ToString' -Force -Value {

--- a/Cmdlets/Private/ConvertTo-TeamViewerDevice.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerDevice.ps1
@@ -5,7 +5,7 @@ function ConvertTo-TeamViewerDevice {
         $InputObject
     )
 
-    begin {
+    process {
         $remoteControlId = $InputObject.remotecontrol_id | `
             Select-String -Pattern 'r(\d+)' | `
             ForEach-Object { $_.Matches.Groups[1].Value }
@@ -27,9 +27,7 @@ function ConvertTo-TeamViewerDevice {
         if ($InputObject.last_seen) {
             $properties['LastSeenAt'] = [datetime]($InputObject.last_seen)
         }
-    }
 
-    process {
         $result = New-Object -TypeName PSObject -Property $properties
         $result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.Device')
         $result | Add-Member -MemberType ScriptMethod -Name 'ToString' -Force -Value {

--- a/Cmdlets/Private/ConvertTo-TeamViewerDevice.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerDevice.ps1
@@ -4,7 +4,8 @@ function ConvertTo-TeamViewerDevice {
         [PSObject]
         $InputObject
     )
-    process {
+
+    begin {
         $remoteControlId = $InputObject.remotecontrol_id | `
             Select-String -Pattern 'r(\d+)' | `
             ForEach-Object { $_.Matches.Groups[1].Value }
@@ -18,17 +19,23 @@ function ConvertTo-TeamViewerDevice {
             IsAssignedToCurrentAccount = $InputObject.assigned_to
             SupportedFeatures          = $InputObject.supported_features
         }
+
         if ($InputObject.policy_id) {
             $properties['PolicyId'] = $InputObject.policy_id
         }
+
         if ($InputObject.last_seen) {
             $properties['LastSeenAt'] = [datetime]($InputObject.last_seen)
         }
+    }
+
+    process {
         $result = New-Object -TypeName PSObject -Property $properties
         $result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.Device')
-        $result | Add-Member -MemberType ScriptMethod -Name "ToString" -Force -Value {
-            Write-Output "$($this.Name)"
+        $result | Add-Member -MemberType ScriptMethod -Name 'ToString' -Force -Value {
+            "$($this.Name)"
         }
-        Write-Output $result
+
+        $result
     }
 }

--- a/Cmdlets/Private/ConvertTo-TeamViewerGroup.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerGroup.ps1
@@ -5,7 +5,7 @@ function ConvertTo-TeamViewerGroup {
         $InputObject
     )
 
-    begin {
+    process {
         $properties = @{
             Id          = $InputObject.id
             Name        = $InputObject.name
@@ -20,9 +20,7 @@ function ConvertTo-TeamViewerGroup {
                 Name   = $InputObject.owner.name
             }
         }
-    }
 
-    process {
         $result = New-Object -TypeName PSObject -Property $properties
         $result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.Group')
 

--- a/Cmdlets/Private/ConvertTo-TeamViewerGroup.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerGroup.ps1
@@ -4,7 +4,8 @@ function ConvertTo-TeamViewerGroup {
         [PSObject]
         $InputObject
     )
-    process {
+
+    begin {
         $properties = @{
             Id          = $InputObject.id
             Name        = $InputObject.name
@@ -12,14 +13,19 @@ function ConvertTo-TeamViewerGroup {
             PolicyId    = $InputObject.policy_id
             SharedWith  = @($InputObject.shared_with | ConvertTo-TeamViewerGroupShare)
         }
+
         if ($InputObject.owner) {
             $properties.Owner = [pscustomobject]@{
                 UserId = $InputObject.owner.userid
                 Name   = $InputObject.owner.name
             }
         }
+    }
+
+    process {
         $result = New-Object -TypeName PSObject -Property $properties
         $result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.Group')
-        Write-Output $result
+
+        $result
     }
 }

--- a/Cmdlets/Private/ConvertTo-TeamViewerGroupShare.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerGroupShare.ps1
@@ -5,15 +5,13 @@ function ConvertTo-TeamViewerGroupShare {
         $InputObject
     )
 
-    begin {
+    process {
         $properties = @{
             UserId      = $InputObject.userid
             Name        = $InputObject.name
             Permissions = $InputObject.permissions
         }
-    }
 
-    process {
         $result = New-Object -TypeName PSObject -Property $properties
         $result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.GroupShare')
         $result | Add-Member -MemberType ScriptMethod -Name 'ToString' -Force -Value {

--- a/Cmdlets/Private/ConvertTo-TeamViewerGroupShare.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerGroupShare.ps1
@@ -4,17 +4,22 @@ function ConvertTo-TeamViewerGroupShare {
         [PSObject]
         $InputObject
     )
-    process {
+
+    begin {
         $properties = @{
             UserId      = $InputObject.userid
             Name        = $InputObject.name
             Permissions = $InputObject.permissions
         }
+    }
+
+    process {
         $result = New-Object -TypeName PSObject -Property $properties
         $result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.GroupShare')
-        $result | Add-Member -MemberType ScriptMethod -Name "ToString" -Force -Value {
-            Write-Output "$($this.UserId)"
+        $result | Add-Member -MemberType ScriptMethod -Name 'ToString' -Force -Value {
+            "$($this.UserId)"
         }
-        Write-Output $result
+
+        $result
     }
 }

--- a/Cmdlets/Private/ConvertTo-TeamViewerLicense.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerLicense.ps1
@@ -5,19 +5,21 @@ function ConvertTo-TeamViewerLicense {
         $InputObject
     )
 
-    process {
+    begin {
         $properties = @{
             CompanyId         = [int]$InputObject.companyId
             CompanyName       = $InputObject.companyName
             AvailableLicenses = @($InputObject.available_licenses | ConvertTo-TeamViewerLicenseInformation)
         }
+    }
 
+    process {
         $result = New-Object -TypeName PSObject -Property $properties
         $result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.License')
         $result | Add-Member -MemberType ScriptMethod -Name 'ToString' -Force -Value {
-            Write-Output "$($this.CompanyName)"
+            "$($this.CompanyName)"
         }
 
-        Write-Output $result
+        $result
     }
 }

--- a/Cmdlets/Private/ConvertTo-TeamViewerLicense.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerLicense.ps1
@@ -5,15 +5,13 @@ function ConvertTo-TeamViewerLicense {
         $InputObject
     )
 
-    begin {
+    process {
         $properties = @{
             CompanyId         = [int]$InputObject.companyId
             CompanyName       = $InputObject.companyName
             AvailableLicenses = @($InputObject.available_licenses | ConvertTo-TeamViewerLicenseInformation)
         }
-    }
 
-    process {
         $result = New-Object -TypeName PSObject -Property $properties
         $result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.License')
         $result | Add-Member -MemberType ScriptMethod -Name 'ToString' -Force -Value {

--- a/Cmdlets/Private/ConvertTo-TeamViewerLicenseInformation.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerLicenseInformation.ps1
@@ -5,7 +5,7 @@ function ConvertTo-TeamViewerLicenseInformation {
         $InputObject
     )
 
-    process {
+    begin {
         $properties = @{
             LicenseName      = $InputObject.licenseName
             Version          = [int]$InputObject.version
@@ -21,13 +21,15 @@ function ConvertTo-TeamViewerLicenseInformation {
             MaxAssignments   = [int]$InputObject.maxAssignments
             TotalTechnicians = [int]$InputObject.totalTechnicians
         }
+    }
 
+    process {
         $result = New-Object -TypeName PSObject -Property $properties
         $result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.LicenseInformation')
         $result | Add-Member -MemberType ScriptMethod -Name 'ToString' -Force -Value {
-            Write-Output "$($this.LicenseName)"
+            "$($this.LicenseName)"
         }
 
-        Write-Output $result
+        $result
     }
 }

--- a/Cmdlets/Private/ConvertTo-TeamViewerLicenseInformation.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerLicenseInformation.ps1
@@ -5,7 +5,7 @@ function ConvertTo-TeamViewerLicenseInformation {
         $InputObject
     )
 
-    begin {
+    process {
         $properties = @{
             LicenseName      = $InputObject.licenseName
             Version          = [int]$InputObject.version
@@ -21,9 +21,7 @@ function ConvertTo-TeamViewerLicenseInformation {
             MaxAssignments   = [int]$InputObject.maxAssignments
             TotalTechnicians = [int]$InputObject.totalTechnicians
         }
-    }
 
-    process {
         $result = New-Object -TypeName PSObject -Property $properties
         $result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.LicenseInformation')
         $result | Add-Member -MemberType ScriptMethod -Name 'ToString' -Force -Value {

--- a/Cmdlets/Private/ConvertTo-TeamViewerManagedDevice.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerManagedDevice.ps1
@@ -5,7 +5,7 @@ function ConvertTo-TeamViewerManagedDevice {
         $InputObject
     )
 
-    begin {
+    process {
         $properties = @{
             Id           = [guid]$InputObject.id
             Name         = $InputObject.name
@@ -20,9 +20,7 @@ function ConvertTo-TeamViewerManagedDevice {
         if ($InputObject.teamviewerPolicyId) {
             $properties['PolicyId'] = [guid]$InputObject.teamviewerPolicyId
         }
-    }
 
-    process {
         $result = New-Object -TypeName PSObject -Property $properties
         $result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.ManagedDevice')
 

--- a/Cmdlets/Private/ConvertTo-TeamViewerManagedDevice.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerManagedDevice.ps1
@@ -4,7 +4,8 @@ function ConvertTo-TeamViewerManagedDevice {
         [PSObject]
         $InputObject
     )
-    process {
+
+    begin {
         $properties = @{
             Id           = [guid]$InputObject.id
             Name         = $InputObject.name
@@ -17,11 +18,14 @@ function ConvertTo-TeamViewerManagedDevice {
         }
 
         if ($InputObject.teamviewerPolicyId) {
-            $properties["PolicyId"] = [guid]$InputObject.teamviewerPolicyId
+            $properties['PolicyId'] = [guid]$InputObject.teamviewerPolicyId
         }
+    }
 
+    process {
         $result = New-Object -TypeName PSObject -Property $properties
         $result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.ManagedDevice')
-        Write-Output $result
+
+        $result
     }
 }

--- a/Cmdlets/Private/ConvertTo-TeamViewerManagedGroup.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerManagedGroup.ps1
@@ -5,7 +5,7 @@ function ConvertTo-TeamViewerManagedGroup {
         $InputObject
     )
 
-    begin {
+    process {
         $properties = @{
             Id   = [guid]$InputObject.id
             Name = $InputObject.name
@@ -14,9 +14,7 @@ function ConvertTo-TeamViewerManagedGroup {
         if ($InputObject.policy_id) {
             $properties['PolicyId'] = $InputObject.policy_id
         }
-    }
 
-    process {
         $result = New-Object -TypeName PSObject -Property $properties
         $result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.ManagedGroup')
 

--- a/Cmdlets/Private/ConvertTo-TeamViewerManagedGroup.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerManagedGroup.ps1
@@ -4,16 +4,22 @@ function ConvertTo-TeamViewerManagedGroup {
         [PSObject]
         $InputObject
     )
-    process {
+
+    begin {
         $properties = @{
             Id   = [guid]$InputObject.id
             Name = $InputObject.name
         }
+
         if ($InputObject.policy_id) {
-            $properties["PolicyId"] = $InputObject.policy_id
+            $properties['PolicyId'] = $InputObject.policy_id
         }
+    }
+
+    process {
         $result = New-Object -TypeName PSObject -Property $properties
         $result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.ManagedGroup')
-        Write-Output $result
+
+        $result
     }
 }

--- a/Cmdlets/Private/ConvertTo-TeamViewerManager.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerManager.ps1
@@ -4,15 +4,16 @@ function ConvertTo-TeamViewerManager {
         [PSObject]
         $InputObject,
 
-        [Parameter(Mandatory = $true, ParameterSetName = "GroupManager")]
+        [Parameter(Mandatory = $true, ParameterSetName = 'GroupManager')]
         [guid]
         $GroupId,
 
-        [Parameter(Mandatory = $true, ParameterSetName = "DeviceManager")]
+        [Parameter(Mandatory = $true, ParameterSetName = 'DeviceManager')]
         [guid]
         $DeviceId
     )
-    process {
+
+    begin {
         $properties = @{
             Id          = [guid]$InputObject.id
             ManagerType = $InputObject.type
@@ -37,9 +38,12 @@ function ConvertTo-TeamViewerManager {
                 $properties.DeviceId = $DeviceId
             }
         }
+    }
 
+    process {
         $result = New-Object -TypeName PSObject -Property $properties
         $result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.Manager')
-        Write-Output $result
+
+        $result
     }
 }

--- a/Cmdlets/Private/ConvertTo-TeamViewerManager.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerManager.ps1
@@ -13,7 +13,7 @@ function ConvertTo-TeamViewerManager {
         $DeviceId
     )
 
-    begin {
+    process {
         $properties = @{
             Id          = [guid]$InputObject.id
             ManagerType = $InputObject.type
@@ -38,9 +38,7 @@ function ConvertTo-TeamViewerManager {
                 $properties.DeviceId = $DeviceId
             }
         }
-    }
 
-    process {
         $result = New-Object -TypeName PSObject -Property $properties
         $result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.Manager')
 

--- a/Cmdlets/Private/ConvertTo-TeamViewerPolicy.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerPolicy.ps1
@@ -5,7 +5,7 @@ function ConvertTo-TeamViewerPolicy {
         $InputObject
     )
 
-    process {
+    begin {
         $properties = @{
             Id       = $InputObject.policy_id
             Name     = $InputObject.name
@@ -19,9 +19,12 @@ function ConvertTo-TeamViewerPolicy {
                 }
             )
         }
+    }
 
+    process {
         $result = New-Object -TypeName PSObject -Property $properties
         $result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.Policy')
-        Write-Output $result
+
+        $result
     }
 }

--- a/Cmdlets/Private/ConvertTo-TeamViewerPolicy.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerPolicy.ps1
@@ -5,7 +5,7 @@ function ConvertTo-TeamViewerPolicy {
         $InputObject
     )
 
-    begin {
+    process {
         $properties = @{
             Id       = $InputObject.policy_id
             Name     = $InputObject.name
@@ -19,9 +19,7 @@ function ConvertTo-TeamViewerPolicy {
                 }
             )
         }
-    }
 
-    process {
         $result = New-Object -TypeName PSObject -Property $properties
         $result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.Policy')
 

--- a/Cmdlets/Private/ConvertTo-TeamViewerPredefinedRole.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerPredefinedRole.ps1
@@ -4,18 +4,20 @@ function ConvertTo-TeamViewerPredefinedRole {
         [PSObject]
         $InputObject
     )
-    process {
-        if ($InputObject) {
-            $properties = @{
-                PredefinedRoleId = $InputObject.PredefinedUserRoleId
-            }
-        }
 
+    begin {
+        $properties = @{
+            PredefinedRoleId = $InputObject.PredefinedUserRoleId
+        }
+    }
+
+    process {
         $result = New-Object -TypeName PSObject -Property $properties
         $result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.PredefinedRole')
         $result | Add-Member -MemberType ScriptMethod -Name 'ToString' -Force -Value {
-            Write-Output "[$($this.PredefinedRoleID)]"
+            "[$($this.PredefinedRoleID)]"
         }
-        Write-Output $result
+
+        $result
     }
 }

--- a/Cmdlets/Private/ConvertTo-TeamViewerPredefinedRole.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerPredefinedRole.ps1
@@ -5,13 +5,11 @@ function ConvertTo-TeamViewerPredefinedRole {
         $InputObject
     )
 
-    begin {
+    process {
         $properties = @{
             PredefinedRoleId = $InputObject.PredefinedUserRoleId
         }
-    }
 
-    process {
         $result = New-Object -TypeName PSObject -Property $properties
         $result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.PredefinedRole')
         $result | Add-Member -MemberType ScriptMethod -Name 'ToString' -Force -Value {

--- a/Cmdlets/Private/ConvertTo-TeamViewerRole.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerRole.ps1
@@ -5,7 +5,7 @@ function ConvertTo-TeamViewerRole {
         $InputObject
     )
 
-    begin {
+    process {
         $properties = @{
             RoleName = $InputObject.Name
             RoleID   = $InputObject.Id
@@ -16,9 +16,7 @@ function ConvertTo-TeamViewerRole {
                 $properties[$permission.Name] = $permission.Value
             }
         }
-    }
 
-    process {
         $result = New-Object -TypeName PSObject -Property $properties
         $result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.Role')
         $result | Add-Member -MemberType ScriptMethod -Name 'ToString' -Force -Value {

--- a/Cmdlets/Private/ConvertTo-TeamViewerRole.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerRole.ps1
@@ -4,22 +4,28 @@ function ConvertTo-TeamViewerRole {
         [PSObject]
         $InputObject
     )
-    process {
+
+    begin {
         $properties = @{
             RoleName = $InputObject.Name
             RoleID   = $InputObject.Id
         }
+
         if ($InputObject.Permissions) {
             foreach ($permission in $InputObject.Permissions.PSObject.Properties) {
                 $properties[$permission.Name] = $permission.Value
             }
         }
+    }
+
+    process {
         $result = New-Object -TypeName PSObject -Property $properties
         $result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.Role')
         $result | Add-Member -MemberType ScriptMethod -Name 'ToString' -Force -Value {
-            Write-Output "[$($this.RoleName)] [$($this.RoleID)] $($this.Permissions))"
+            "[$($this.RoleName)] [$($this.RoleID)] $($this.Permissions))"
         }
-        Write-Output $result
+
+        $result
     }
 }
 

--- a/Cmdlets/Private/ConvertTo-TeamViewerRoleAssignedUser.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerRoleAssignedUser.ps1
@@ -5,13 +5,11 @@ function ConvertTo-TeamViewerRoleAssignedUser {
         $InputObject
     )
 
-    begin {
+    process {
         $properties = @{
             AssignedUsers = ($InputObject.trim('u'))
         }
-    }
 
-    process {
         $result = New-Object -TypeName PSObject -Property $properties
         $result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.RoleAssignedUser')
 

--- a/Cmdlets/Private/ConvertTo-TeamViewerRoleAssignedUser.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerRoleAssignedUser.ps1
@@ -4,10 +4,17 @@ function ConvertTo-TeamViewerRoleAssignedUser {
         [PSObject]
         $InputObject
     )
+
+    begin {
+        $properties = @{
+            AssignedUsers = ($InputObject.trim('u'))
+        }
+    }
+
     process {
-        $properties = @{AssignedUsers = ($InputObject.trim('u'))}
         $result = New-Object -TypeName PSObject -Property $properties
         $result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.RoleAssignedUser')
-        Write-Output $result
+
+        $result
     }
 }

--- a/Cmdlets/Private/ConvertTo-TeamViewerRoleAssignedUserGroup.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerRoleAssignedUserGroup.ps1
@@ -5,13 +5,11 @@ function ConvertTo-TeamViewerRoleAssignedUserGroup {
         $InputObject
     )
 
-    begin {
+    process {
         $properties = @{
             AssignedGroups = ($InputObject)
         }
-    }
 
-    process {
         $result = New-Object -TypeName PSObject -Property $properties
         $result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.RoleAssignedUserGroup')
 

--- a/Cmdlets/Private/ConvertTo-TeamViewerRoleAssignedUserGroup.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerRoleAssignedUserGroup.ps1
@@ -4,10 +4,17 @@ function ConvertTo-TeamViewerRoleAssignedUserGroup {
         [PSObject]
         $InputObject
     )
+
+    begin {
+        $properties = @{
+            AssignedGroups = ($InputObject)
+        }
+    }
+
     process {
-        $properties = @{AssignedGroups = ($InputObject)}
         $result = New-Object -TypeName PSObject -Property $properties
         $result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.RoleAssignedUserGroup')
-        Write-Output $result
+
+        $result
     }
 }

--- a/Cmdlets/Private/ConvertTo-TeamViewerSsoDomain.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerSsoDomain.ps1
@@ -5,14 +5,12 @@ function ConvertTo-TeamViewerSsoDomain {
         $InputObject
     )
 
-    begin {
+    process {
         $properties = @{
             Id   = $InputObject.DomainId
             Name = $InputObject.DomainName
         }
-    }
 
-    process {
         $result = New-Object -TypeName PSObject -Property $properties
         $result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.SsoDomain')
         $result | Add-Member -MemberType ScriptMethod -Name 'ToString' -Force -Value {

--- a/Cmdlets/Private/ConvertTo-TeamViewerSsoDomain.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerSsoDomain.ps1
@@ -4,16 +4,21 @@ function ConvertTo-TeamViewerSsoDomain {
         [PSObject]
         $InputObject
     )
-    process {
+
+    begin {
         $properties = @{
             Id   = $InputObject.DomainId
             Name = $InputObject.DomainName
         }
+    }
+
+    process {
         $result = New-Object -TypeName PSObject -Property $properties
         $result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.SsoDomain')
-        $result | Add-Member -MemberType ScriptMethod -Name "ToString" -Force -Value {
-            Write-Output "$($this.Name)"
+        $result | Add-Member -MemberType ScriptMethod -Name 'ToString' -Force -Value {
+            "$($this.Name)"
         }
-        Write-Output $result
+
+        $result
     }
 }

--- a/Cmdlets/Private/ConvertTo-TeamViewerUser.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerUser.ps1
@@ -9,7 +9,7 @@ function ConvertTo-TeamViewerUser {
         $PropertiesToLoad = 'All'
     )
 
-    begin {
+    process {
         $properties = @{
             Id    = $InputObject.id
             Name  = $InputObject.name
@@ -62,9 +62,7 @@ function ConvertTo-TeamViewerUser {
                 }
             }
         }
-    }
 
-    process {
         $result = New-Object -TypeName PSObject -Property $properties
         $result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.User')
         $result | Add-Member -MemberType ScriptMethod -Name 'ToString' -Force -Value {

--- a/Cmdlets/Private/ConvertTo-TeamViewerUser.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerUser.ps1
@@ -9,7 +9,7 @@ function ConvertTo-TeamViewerUser {
         $PropertiesToLoad = 'All'
     )
 
-    process {
+    begin {
         $properties = @{
             Id    = $InputObject.id
             Name  = $InputObject.name
@@ -21,7 +21,7 @@ function ConvertTo-TeamViewerUser {
             }
         }
 
-        if ($PropertiesToLoad -Eq 'All') {
+        if ($PropertiesToLoad -eq 'All') {
             $properties += @{
                 Active            = $InputObject.active
                 LastAccessDate    = $InputObject.last_access_date
@@ -62,13 +62,15 @@ function ConvertTo-TeamViewerUser {
                 }
             }
         }
+    }
 
+    process {
         $result = New-Object -TypeName PSObject -Property $properties
         $result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.User')
         $result | Add-Member -MemberType ScriptMethod -Name 'ToString' -Force -Value {
-            Write-Output "$($this.Name) <$($this.Email)>"
+            "$($this.Name) <$($this.Email)>"
         }
 
-        Write-Output $result
+        $result
     }
 }

--- a/Cmdlets/Private/ConvertTo-TeamViewerUserGroup.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerUserGroup.ps1
@@ -4,13 +4,18 @@ function ConvertTo-TeamViewerUserGroup {
         [PSObject]
         $InputObject
     )
-    process {
+
+    begin {
         $properties = @{
             Id   = [UInt64]$InputObject.id
             Name = $InputObject.name
         }
+    }
+
+    process {
         $result = New-Object -TypeName PSObject -Property $properties
         $result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.UserGroup')
-        Write-Output $result
+
+        $result
     }
 }

--- a/Cmdlets/Private/ConvertTo-TeamViewerUserGroup.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerUserGroup.ps1
@@ -5,14 +5,12 @@ function ConvertTo-TeamViewerUserGroup {
         $InputObject
     )
 
-    begin {
+    process {
         $properties = @{
             Id   = [UInt64]$InputObject.id
             Name = $InputObject.name
         }
-    }
 
-    process {
         $result = New-Object -TypeName PSObject -Property $properties
         $result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.UserGroup')
 

--- a/Cmdlets/Private/ConvertTo-TeamViewerUserGroupAssignedRole.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerUserGroupAssignedRole.ps1
@@ -5,13 +5,11 @@ function ConvertTo-TeamViewerRoleAssignedUserGroup {
         $InputObject
     )
 
-    begin {
+    process {
         $properties = @{
             AssignedGroups = ($InputObject)
         }
-    }
 
-    process {
         $result = New-Object -TypeName PSObject -Property $properties
         $result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.UserGroupAssignedRole')
 

--- a/Cmdlets/Private/ConvertTo-TeamViewerUserGroupAssignedRole.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerUserGroupAssignedRole.ps1
@@ -4,10 +4,17 @@ function ConvertTo-TeamViewerRoleAssignedUserGroup {
         [PSObject]
         $InputObject
     )
+
+    begin {
+        $properties = @{
+            AssignedGroups = ($InputObject)
+        }
+    }
+
     process {
-        $properties = @{AssignedRole = ($InputObject) }
         $result = New-Object -TypeName PSObject -Property $properties
         $result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.UserGroupAssignedRole')
-        Write-Output $result
+
+        $result
     }
 }

--- a/Cmdlets/Private/ConvertTo-TeamViewerUserGroupMember.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerUserGroupMember.ps1
@@ -4,13 +4,18 @@ function ConvertTo-TeamViewerUserGroupMember {
         [PSObject]
         $InputObject
     )
-    process {
+
+    begin {
         $properties = @{
             AccountId = [int]$InputObject.accountId
             Name      = $InputObject.name
         }
+    }
+
+    process {
         $result = New-Object -TypeName PSObject -Property $properties
         $result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.UserGroupMember')
-        Write-Output $result
+
+        $result
     }
 }

--- a/Cmdlets/Private/ConvertTo-TeamViewerUserGroupMember.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerUserGroupMember.ps1
@@ -5,14 +5,12 @@ function ConvertTo-TeamViewerUserGroupMember {
         $InputObject
     )
 
-    begin {
+    process {
         $properties = @{
             AccountId = [int]$InputObject.accountId
             Name      = $InputObject.name
         }
-    }
 
-    process {
         $result = New-Object -TypeName PSObject -Property $properties
         $result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.UserGroupMember')
 

--- a/Cmdlets/Private/Get-TeamViewerApiUri.ps1
+++ b/Cmdlets/Private/Get-TeamViewerApiUri.ps1
@@ -1,5 +1,3 @@
-
-
 class TeamViewerConfiguration {
     [string]$APIUri = 'https://webapi.teamviewer.com/api/v1'
 
@@ -16,7 +14,6 @@ class TeamViewerConfiguration {
 
 function Get-TeamViewerAPIUri {
     $config = [TeamViewerConfiguration]::GetInstance()
+
     return $config.APIUri
 }
-
-

--- a/Cmdlets/Private/Get-TeamViewerRegKeyPath.ps1
+++ b/Cmdlets/Private/Get-TeamViewerRegKeyPath.ps1
@@ -5,10 +5,14 @@ function Get-TeamViewerRegKeyPath {
         [string]
         $Variant = 'Auto'
     )
-    if (($Variant -eq 'WOW6432') -Or (Test-TeamViewer32on64)) {
-        Write-Output 'HKLM:\SOFTWARE\Wow6432Node\TeamViewer'
-    }
-    else {
-        Write-Output 'HKLM:\SOFTWARE\TeamViewer'
+
+    process {
+        if (($Variant -eq 'WOW6432') -or (Test-TeamViewer32on64)) {
+            'HKLM:\SOFTWARE\Wow6432Node\TeamViewer'
+        }
+
+        else {
+            'HKLM:\SOFTWARE\TeamViewer'
+        }
     }
 }

--- a/Cmdlets/Private/Invoke-TeamViewerRestMethod.ps1
+++ b/Cmdlets/Private/Invoke-TeamViewerRestMethod.ps1
@@ -25,69 +25,81 @@ function Invoke-TeamViewerRestMethod {
 
     )
 
-    if (-not $Headers) {
-        $Headers = @{ }
-        $PSBoundParameters.Add('Headers', $Headers) | Out-Null
+    begin {
+        if (-not $Headers) {
+            $Headers = @{ }
+            $PSBoundParameters.Add('Headers', $Headers) | Out-Null
+        }
+
+        if ($global:TeamViewerProxyUriSet) {
+            $Proxy = $global:TeamViewerProxyUriSet
+        }
+        elseif ([Environment]::GetEnvironmentVariable('TeamViewerProxyUri') ) {
+            $Proxy = [Environment]::GetEnvironmentVariable('TeamViewerProxyUri')
+
+            if ($global:TeamViewerProxyUriRemoved) {
+                $Proxy = $null
+            }
+        }
+
+        if ($Proxy) {
+            $PSBoundParameters.Add('Proxy', $Proxy) | Out-Null
+        }
     }
 
-    if ($global:TeamViewerProxyUriSet) {
-        $Proxy = $global:TeamViewerProxyUriSet
-    }
-    elseif ([Environment]::GetEnvironmentVariable('TeamViewerProxyUri') ) {
-        $Proxy = [Environment]::GetEnvironmentVariable('TeamViewerProxyUri')
-        if ($global:TeamViewerProxyUriRemoved) {
-            $Proxy = $null
-        }
-    }
-    if ($Proxy) {
-        $PSBoundParameters.Add('Proxy', $Proxy) | Out-Null
-    }
-    $bstr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($ApiToken)
-    $Headers['Authorization'] = "Bearer $([System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($bstr))"
-    [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr) | Out-Null
-    $PSBoundParameters.Remove('ApiToken') | Out-Null
-    $PSBoundParameters.Remove('WriteErrorTo') | Out-Null
+    process {
+        $bstr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($ApiToken)
+        $Headers['Authorization'] = "Bearer $([System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($bstr))"
 
-    $currentTlsSettings = [Net.ServicePointManager]::SecurityProtocol
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+        [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr) | Out-Null
+        $PSBoundParameters.Remove('ApiToken') | Out-Null
+        $PSBoundParameters.Remove('WriteErrorTo') | Out-Null
 
-    $currentProgressPreference = $ProgressPreference
-    $ProgressPreference = 'SilentlyContinue'
+        $currentTlsSettings = [Net.ServicePointManager]::SecurityProtocol
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
-    # Using `Invoke-WebRequest` instead of `Invoke-RestMethod`:
-    # There is a known issue for PUT and DELETE operations to hang on Windows Server 2012.
-    try {
-        # -DateKind String (PS 7.5+) prevents auto-deserialization of date strings to DateTime objects,
-        # which avoids locale-dependent day/month swapping and loss of precision.
-        $convertParams = if ($PSVersionTable.PSVersion -ge [version]'7.5') {
-            @{ DateKind = 'String' } 
+        $currentProgressPreference = $ProgressPreference
+        $ProgressPreference = 'SilentlyContinue'
+
+        # Using `Invoke-WebRequest` instead of `Invoke-RestMethod`:
+        # There is a known issue for PUT and DELETE operations to hang on Windows Server 2012.
+        try {
+            # -DateKind String (PS 7.5+) prevents auto-deserialization of date strings to DateTime objects,
+            # which avoids locale-dependent day/month swapping and loss of precision.
+            $convertParams = if ($PSVersionTable.PSVersion -ge [version]'7.5') {
+                @{ DateKind = 'String' }
+            }
+            else {
+                @{}
+            }
+
+            return ((Invoke-WebRequest -UseBasicParsing @PSBoundParameters).Content | ConvertFrom-Json @convertParams)
         }
-        else {
-            @{} 
+        catch {
+            $msg = $null
+
+            if ($PSVersionTable.PSVersion.Major -ge 6) {
+                $msg = $_.ErrorDetails.Message
+            }
+            elseif ($_.Exception.Response) {
+                $stream = $_.Exception.Response.GetResponseStream()
+                $reader = New-Object System.IO.StreamReader($stream)
+                $reader.BaseStream.Position = 0
+                $msg = $reader.ReadToEnd()
+            }
+
+            $err = ($msg | ConvertTo-TeamViewerRestError)
+
+            if ($WriteErrorTo) {
+                $WriteErrorTo.WriteError(($err | ConvertTo-ErrorRecord))
+            }
+            else {
+                throw $err
+            }
         }
-        return ((Invoke-WebRequest -UseBasicParsing @PSBoundParameters).Content | ConvertFrom-Json @convertParams)
-    }
-    catch {
-        $msg = $null
-        if ($PSVersionTable.PSVersion.Major -ge 6) {
-            $msg = $_.ErrorDetails.Message
+        finally {
+            [Net.ServicePointManager]::SecurityProtocol = $currentTlsSettings
+            $ProgressPreference = $currentProgressPreference
         }
-        elseif ($_.Exception.Response) {
-            $stream = $_.Exception.Response.GetResponseStream()
-            $reader = New-Object System.IO.StreamReader($stream)
-            $reader.BaseStream.Position = 0
-            $msg = $reader.ReadToEnd()
-        }
-        $err = ($msg | ConvertTo-TeamViewerRestError)
-        if ($WriteErrorTo) {
-            $WriteErrorTo.WriteError(($err | ConvertTo-ErrorRecord))
-        }
-        else {
-            throw $err
-        }
-    }
-    finally {
-        [Net.ServicePointManager]::SecurityProtocol = $currentTlsSettings
-        $ProgressPreference = $currentProgressPreference
     }
 }

--- a/Cmdlets/Private/Test-TeamViewer32on64.ps1
+++ b/Cmdlets/Private/Test-TeamViewer32on64.ps1
@@ -1,15 +1,21 @@
 function Test-TeamViewer32on64 {
-    if (![Environment]::Is64BitOperatingSystem) {
+    param()
+
+    if (-not([Environment]::Is64BitOperatingSystem)) {
         return $false
     }
-    $registryKey = Get-TeamViewerRegKeyPath -Variant WOW6432
-    if (!(Test-Path $registryKey)) {
+
+    $TV_RegKey = Get-TeamViewerRegKeyPath -Variant WOW6432
+
+    if (-not (Test-Path -Path $TV_RegKey -PathType Container)) {
         return $false
     }
+
     try {
-        $installationDirectory = (Get-Item $registryKey).GetValue('InstallationDirectory')
-        $binaryPath = Join-Path $installationDirectory 'TeamViewer.exe'
-        return Test-Path $binaryPath
+        $TV_InstallationDirectory = (Get-Item -Path $TV_RegKey).GetValue('InstallationDirectory')
+        $TV_AppFilePath = (Join-Path -Path $TV_InstallationDirectory -ChildPath 'TeamViewer.exe')
+
+        return Test-Path -Path $TV_AppFilePath
     }
     catch {
         return $false

--- a/Tests/Private/ConvertTo-TeamViewerCompany.Tests.ps1
+++ b/Tests/Private/ConvertTo-TeamViewerCompany.Tests.ps1
@@ -1,0 +1,43 @@
+BeforeAll {
+    . "$PSScriptRoot\..\..\Cmdlets\Private\ConvertTo-DateTime.ps1"
+    . "$PSScriptRoot\..\..\Cmdlets\Private\ConvertTo-TeamViewerCompany.ps1"
+}
+
+Describe 'ConvertTo-TeamViewerCompany' {
+    It 'Should map company properties including CreatedAt when present' {
+        $companyInput = [pscustomobject]@{
+            companyId   = '42'
+            companyName = 'Acme Corp'
+            createdAt   = '2026-08-10T12:34:56Z'
+        }
+
+        $result = $companyInput | ConvertTo-TeamViewerCompany
+
+        $result.CompanyId | Should -Be 42
+        $result.CompanyName | Should -Be 'Acme Corp'
+        $result.CreatedAt | Should -Be ([datetime]'2026-08-10T12:34:56Z')
+    }
+
+    It 'Should keep CreatedAt null when not present in input' {
+        $companyInput = [pscustomobject]@{
+            companyId   = 7
+            companyName = 'No Date Ltd'
+        }
+
+        $result = $companyInput | ConvertTo-TeamViewerCompany
+
+        $result.CreatedAt | Should -BeNull
+    }
+
+    It 'Should expose TeamViewerPS.Company type name and custom ToString output' {
+        $companyInput = [pscustomobject]@{
+            companyId   = 5
+            companyName = 'Contoso'
+        }
+
+        $result = $companyInput | ConvertTo-TeamViewerCompany
+
+        $result.PSObject.TypeNames[0] | Should -Be 'TeamViewerPS.Company'
+        $result.ToString() | Should -Be 'Contoso'
+    }
+}


### PR DESCRIPTION
## Summary

Harmonizes the style and structure of all private `ConvertTo-*` functions across the module for consistency.

## Changes

- Applied consistent coding conventions to all 24 private `ConvertTo-*` functions
- Harmonized `Get-TeamViewerApiUri` and `Get-TeamViewerRegKeyPath`
- Refactored `Invoke-TeamViewerRestMethod` for consistency

## Testing

- Lint: `Invoke-ScriptAnalyzer` passes
- Tests: `Invoke-Pester` passes