### PR TITLE
Automate release module versioning

### DIFF
--- a/.github/workflows/publish_production.yml
+++ b/.github/workflows/publish_production.yml
@@ -2,6 +2,11 @@ name: Publish_Production
 
 on:
   workflow_dispatch:
+    inputs:
+      module_version:
+        description: 'Module version (e.g. 3.0.1) to publish'
+        required: true
+        type: string
   release:
     types: [published]
 
@@ -15,7 +20,7 @@ jobs:
 
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE, so the job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install required PowerShell modules
         shell: pwsh
@@ -44,7 +49,17 @@ jobs:
           $ProgressPreference = 'SilentlyContinue'
           $ErrorActionPreference = 'Stop'
 
-          & (Join-Path -Path $env:GITHUB_WORKSPACE -ChildPath 'Build\New-Package.ps1') -Verbose
+          $ModuleVersion = if ('${{ github.event_name }}' -eq 'release') {
+            '${{ github.event.release.tag_name }}'.TrimStart('v')
+          } else {
+            '${{ inputs.module_version }}'
+          }
+
+          if ($ModuleVersion -notmatch '^\d+\.\d+\.\d+$') {
+            throw "Module version must use the format X.Y.Z. Received: $ModuleVersion"
+          }
+
+          & (Join-Path -Path $env:GITHUB_WORKSPACE -ChildPath 'Build\New-Package.ps1') -Module_Version $ModuleVersion -Verbose
 
       # Publish to PowershellGallery.com
       - name: Publish to PowershellGallery.com

--- a/Build/New-Package.ps1
+++ b/Build/New-Package.ps1
@@ -2,7 +2,10 @@
 
 param(
     [Parameter()]
-    [string]$Build_OutputPath = "$(Resolve-Path "$PSScriptRoot\..")\Build\TeamViewerPS"
+    [string]$Build_OutputPath = "$(Resolve-Path "$PSScriptRoot\..")\Build\TeamViewerPS",
+
+    [Parameter()]
+    [version]$Module_Version
 )
 
 $Repo_RootPath = Resolve-Path -Path "$PSScriptRoot\.."
@@ -41,6 +44,10 @@ Copy-Item -Path (Join-Path -Path $Repo_CmdletPath -ChildPath 'TeamViewerPS.psd1'
 Copy-Item -Path (Join-Path -Path $Repo_CmdletPath -ChildPath '*.format.ps1xml') -Destination $Build_OutputPath
 
 Update-Metadata -Path (Join-Path -Path $Build_OutputPath -ChildPath 'TeamViewerPS.psd1') -PropertyName 'FunctionsToExport' -Value $PublicFunctions.BaseName
+
+if ($PSBoundParameters.ContainsKey('Module_Version')) {
+    Update-Metadata -Path (Join-Path -Path $Build_OutputPath -ChildPath 'TeamViewerPS.psd1') -PropertyName 'ModuleVersion' -Value $Module_Version
+}
 
 # Copy additional package files
 Write-Verbose 'Copying additional files into the package...'


### PR DESCRIPTION
## Summary

Automatically set the PowerShell module version during release packaging instead of requiring a manual edit to `Cmdlets/TeamViewerPS.psd1`.

## Changes

- Derive the version from the published release tag (`vX.Y.Z`).
- Require and validate `module_version` for manual workflow runs.
- Pass the version to `Build/New-Package.ps1` and apply it to the generated manifest.
- Keep the checked-in manifest unchanged as the development fallback.

## Validation

- `Invoke-ScriptAnalyzer -Path . -Recurse -Settings .\Linters\PSScriptAnalyzer.psd1 -ReportSummary -EnableExit`
- `Invoke-Pester -Path . -Output Detailed -CI`
- Temporary package build verified generated manifest version `9.8.7`.
