### PR TITLE
Standardize public CmdletBinding usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ Invoke-Build -Task Test
 - Preserve public function names and parameter contracts unless explicitly asked to change them.
 - Prefer existing helpers in `Cmdlets/Private` over new abstractions.
 - Follow naming conventions: `ConvertTo-*` for mapping, `Resolve-*` for lookups
+- **CmdletBinding**: All public cmdlets must declare `[CmdletBinding()]`; add `SupportsShouldProcess = $true` only when the cmdlet uses `ShouldProcess` for a mutation. Private helpers should declare `CmdletBinding` only when they need common parameters or other advanced-function features. Parameterless functions using `CmdletBinding` must include an empty `param()` block.
 - **Pipeline Output Pattern**: Process blocks must use implicit pipeline emission (no `return` or `Write-Output`); non-pipeline functions use explicit `return` statements. This standardizes when values enter the pipeline vs. are explicitly returned.
 - Add or update Pester tests for every behavior change; include a regression test for bug fixes.
 - Run lint and tests before finishing; both must pass.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## x.x.x (YYYY-xx-xx)
+
+### Changed
+
+- Adds `CmdletBinding` to public commands.
+
 ## 3.0.2 (2026-08-13)
 
 ### Added

--- a/Cmdlets/Public/Connect-TeamViewerApi.ps1
+++ b/Cmdlets/Public/Connect-TeamViewerApi.ps1
@@ -1,4 +1,6 @@
 function Connect-TeamViewerApi {
+    [CmdletBinding()]
+
     param(
         [Parameter(Mandatory = $true)]
         [securestring]

--- a/Cmdlets/Public/Disconnect-TeamViewerApi.ps1
+++ b/Cmdlets/Public/Disconnect-TeamViewerApi.ps1
@@ -1,3 +1,7 @@
 function Disconnect-TeamViewerApi {
-    $global:PSDefaultParameterValues.Remove("*-Teamviewer*:ApiToken")
+    [CmdletBinding()]
+
+    param()
+
+    $global:PSDefaultParameterValues.Remove('*-Teamviewer*:ApiToken')
 }

--- a/Cmdlets/Public/Get-TeamViewerAccount.ps1
+++ b/Cmdlets/Public/Get-TeamViewerAccount.ps1
@@ -1,4 +1,6 @@
 function Get-TeamViewerAccount {
+    [CmdletBinding()]
+
     param(
         [Parameter(Mandatory = $true)]
         [securestring]
@@ -13,5 +15,6 @@ function Get-TeamViewerAccount {
         -Method Get `
         -WriteErrorTo $PSCmdlet `
         -ErrorAction Stop
+
     Write-Output ($response | ConvertTo-TeamViewerAccount)
 }

--- a/Cmdlets/Public/Get-TeamViewerCompany.ps1
+++ b/Cmdlets/Public/Get-TeamViewerCompany.ps1
@@ -1,4 +1,6 @@
 function Get-TeamViewerCompany {
+    [CmdletBinding()]
+
     param(
         [Parameter(Mandatory = $true)]
         [securestring]

--- a/Cmdlets/Public/Get-TeamViewerCompanyManagedDevice.ps1
+++ b/Cmdlets/Public/Get-TeamViewerCompanyManagedDevice.ps1
@@ -1,4 +1,6 @@
 function Get-TeamViewerCompanyManagedDevice {
+    [CmdletBinding()]
+
     param(
         [Parameter(Mandatory = $true)]
         [securestring]
@@ -18,6 +20,7 @@ function Get-TeamViewerCompanyManagedDevice {
             -ErrorAction Stop
 
         $parameters.paginationToken = $response.nextPaginationToken
+
         Write-Output ($response.resources | ConvertTo-TeamViewerManagedDevice)
     } while ($parameters.paginationToken)
 }

--- a/Cmdlets/Public/Get-TeamViewerCustomModuleId.ps1
+++ b/Cmdlets/Public/Get-TeamViewerCustomModuleId.ps1
@@ -1,12 +1,17 @@
 function Get-TeamViewerCustomModuleId {
+    [CmdletBinding()]
 
-    if (Test-TeamViewerinstallation) {
+    param()
+
+    if (Test-TeamViewerInstallation) {
         $fileName = 'TeamViewer.json'
         $installationDirectory = Get-TeamViewerInstallationDirectory
         $filePath = Join-Path -Path $installationDirectory -ChildPath $fileName
+
         if (Test-Path -Path $filePath) {
             $jsonContent = Get-Content -Path $FilePath -Raw
             $jsonObject = ConvertFrom-Json $jsonContent
+
             if ($jsonObject.id) {
                 return $jsonObject.id
             }

--- a/Cmdlets/Public/Get-TeamViewerId.ps1
+++ b/Cmdlets/Public/Get-TeamViewerId.ps1
@@ -1,4 +1,8 @@
 function Get-TeamViewerId {
+    [CmdletBinding()]
+
+    param()
+
     if (Test-TeamViewerInstallation) {
         Write-Output (Get-ItemPropertyValue -Path (Get-TeamViewerRegKeyPath) -Name 'ClientID')
     }

--- a/Cmdlets/Public/Get-TeamViewerInstallationDirectory.ps1
+++ b/Cmdlets/Public/Get-TeamViewerInstallationDirectory.ps1
@@ -1,4 +1,6 @@
 function Get-TeamViewerInstallationDirectory {
+    [CmdletBinding()]
+
     $TV_RegKey = Get-TeamViewerRegKeyPath
 
     if (Test-Path -Path $TV_RegKey -PathType Container) {

--- a/Cmdlets/Public/Get-TeamViewerInstallationPackage.ps1
+++ b/Cmdlets/Public/Get-TeamViewerInstallationPackage.ps1
@@ -1,4 +1,8 @@
 function Get-TeamViewerInstallationPackage {
+    [CmdletBinding()]
+
+    param()
+
     if (Test-TeamViewerInstallation) {
         $TV_InstallationDirectory = Get-TeamViewerInstallationDirectory
 

--- a/Cmdlets/Public/Get-TeamViewerLicense.ps1
+++ b/Cmdlets/Public/Get-TeamViewerLicense.ps1
@@ -1,4 +1,6 @@
 function Get-TeamViewerLicense {
+    [CmdletBinding()]
+
     param(
         [Parameter(Mandatory = $true)]
         [securestring]

--- a/Cmdlets/Public/Get-TeamViewerLogFilePath.ps1
+++ b/Cmdlets/Public/Get-TeamViewerLogFilePath.ps1
@@ -1,4 +1,6 @@
 function Get-TeamViewerLogFilePath {
+    [CmdletBinding()]
+
     param()
 
     begin {

--- a/Cmdlets/Public/Get-TeamViewerManagementId.ps1
+++ b/Cmdlets/Public/Get-TeamViewerManagementId.ps1
@@ -1,12 +1,20 @@
 function Get-TeamViewerManagementId {
+    [CmdletBinding()]
+
+    param()
+
     if (Test-TeamViewerInstallation) {
         $regKeyPath = Join-Path (Get-TeamViewerRegKeyPath) 'DeviceManagementV2'
-        $regKey = if (Test-Path -LiteralPath $regKeyPath) { Get-Item -Path $regKeyPath }
+        $regKey = if (Test-Path -LiteralPath $regKeyPath) {
+            Get-Item -Path $regKeyPath
+        }
+
         if ($regKey) {
             $unmanaged = [bool]($regKey.GetValue('Unmanaged'))
             $managementId = $regKey.GetValue('ManagementId')
         }
-        if (!$unmanaged -And $managementId) {
+
+        if (!$unmanaged -and $managementId) {
             Write-Output ([guid]$managementId)
         }
     }

--- a/Cmdlets/Public/Get-TeamViewerPredefinedRole.ps1
+++ b/Cmdlets/Public/Get-TeamViewerPredefinedRole.ps1
@@ -1,4 +1,6 @@
 function Get-TeamViewerPredefinedRole {
+    [CmdletBinding()]
+
     param(
         [Parameter(Mandatory = $true)]
         [securestring]
@@ -6,12 +8,12 @@ function Get-TeamViewerPredefinedRole {
     )
 
 
-    Begin {
+    begin {
         $parameters = @{}
         $resourceUri = "$(Get-TeamViewerApiUri)/userroles/predefined"
     }
 
-    Process {
+    process {
         $response = Invoke-TeamViewerRestMethod `
             -ApiToken $ApiToken `
             -Uri $resourceUri `
@@ -19,7 +21,7 @@ function Get-TeamViewerPredefinedRole {
             -Body $parameters `
             -WriteErrorTo $PSCmdlet `
             -ErrorAction Stop
-        Write-Output ($response | ConvertTo-TeamViewerPredefinedRole)
 
+        Write-Output ($response | ConvertTo-TeamViewerPredefinedRole)
     }
 }

--- a/Cmdlets/Public/Get-TeamViewerRoleByUser.ps1
+++ b/Cmdlets/Public/Get-TeamViewerRoleByUser.ps1
@@ -1,4 +1,6 @@
 function Get-TeamViewerRoleByUser {
+    [CmdletBinding()]
+
     param(
         [Parameter(Mandatory = $true)]
         [securestring]
@@ -17,8 +19,10 @@ function Get-TeamViewerRoleByUser {
         $parameters = $null
         $list = @()
     }
+
     process {
         $resourceUri = $copyUri
+
         do {
             $response = Invoke-TeamViewerRestMethod `
                 -ApiToken $ApiToken `
@@ -31,10 +35,12 @@ function Get-TeamViewerRoleByUser {
             if ($response.assignedRoleIds -and $response.assignedRoleIds.Count -gt 0) {
                 $list += $response.assignedRoleIds
             }
+
             if ($response.nextPaginationToken) {
                 $resourceUri = $copyUri + '?paginationToken=' + $response.nextPaginationToken
             }
         } while ($response.nextPaginationToken)
+
         return $list
     }
 }

--- a/Cmdlets/Public/Get-TeamViewerRoleByUserGroup.ps1
+++ b/Cmdlets/Public/Get-TeamViewerRoleByUserGroup.ps1
@@ -1,4 +1,6 @@
 function Get-TeamViewerRoleByUserGroup {
+    [CmdletBinding()]
+
     param(
         [Parameter(Mandatory = $true)]
         [securestring]
@@ -12,11 +14,12 @@ function Get-TeamViewerRoleByUserGroup {
         $GroupId
     )
 
-    Begin {
+    begin {
         $resourceUri = "$(Get-TeamViewerApiUri)/usergroups/$GroupId/userroles"
         $parameters = $null
     }
-    Process {
+
+    process {
         do {
             $response = Invoke-TeamViewerRestMethod `
                 -ApiToken $ApiToken `
@@ -25,12 +28,15 @@ function Get-TeamViewerRoleByUserGroup {
                 -Body $parameters `
                 -WriteErrorTo $PSCmdlet `
                 -ErrorAction Stop
+
             if ($response.ContinuationToken) {
                 $resourceUri += '&continuationToken=' + $response.ContinuationToken
             }
+
             if ($null -eq $response.assignedRoleId) {
                 return $null
             }
+
             Write-Output ($response.assignedRoleId | ConvertTo-TeamViewerRoleAssignedUserGroup )
         }while ($response.ContinuationToken)
     }

--- a/Cmdlets/Public/Get-TeamViewerService.ps1
+++ b/Cmdlets/Public/Get-TeamViewerService.ps1
@@ -1,4 +1,8 @@
 function Get-TeamViewerService {
+    [CmdletBinding()]
+
+    param()
+
     if (Test-TeamViewerInstallation) {
         Get-Service -Name 'TeamViewer'
     }

--- a/Cmdlets/Public/Get-TeamViewerSsoExclusion.ps1
+++ b/Cmdlets/Public/Get-TeamViewerSsoExclusion.ps1
@@ -1,4 +1,6 @@
 function Get-TeamViewerSsoExclusion {
+    [CmdletBinding()]
+
     param(
         [Parameter(Mandatory = $true)]
         [securestring]
@@ -6,14 +8,15 @@ function Get-TeamViewerSsoExclusion {
 
         [Parameter(Mandatory = $true)]
         [ValidateScript( { $_ | Resolve-TeamViewerSsoDomainId } )]
-        [Alias("Domain")]
+        [Alias('Domain')]
         [object]
         $DomainId
     )
 
     $id = $DomainId | Resolve-TeamViewerSsoDomainId
-    $resourceUri = "$(Get-TeamViewerApiUri)/ssoDomain/$id/exclusion";
+    $resourceUri = "$(Get-TeamViewerApiUri)/ssoDomain/$id/exclusion"
     $parameters = @{ }
+
     do {
         $response = Invoke-TeamViewerRestMethod `
             -ApiToken $ApiToken `
@@ -24,6 +27,7 @@ function Get-TeamViewerSsoExclusion {
             -ErrorAction Stop
 
         Write-Output $response.emails
+
         $parameters.ct = $response.continuation_token
     } while ($parameters.ct)
 }

--- a/Cmdlets/Public/Get-TeamViewerSsoInclusion.ps1
+++ b/Cmdlets/Public/Get-TeamViewerSsoInclusion.ps1
@@ -1,4 +1,6 @@
 function Get-TeamViewerSsoInclusion {
+    [CmdletBinding()]
+
     param(
         [Parameter(Mandatory = $true)]
         [securestring]
@@ -14,6 +16,7 @@ function Get-TeamViewerSsoInclusion {
     $id = $DomainId | Resolve-TeamViewerSsoDomainId
     $resourceUri = "$(Get-TeamViewerApiUri)/ssoDomain/$id/inclusion"
     $parameters = @{ }
+
     do {
         $response = Invoke-TeamViewerRestMethod `
             -ApiToken $ApiToken `
@@ -24,6 +27,7 @@ function Get-TeamViewerSsoInclusion {
             -ErrorAction Stop
 
         Write-Output $response.emails
+
         $parameters.ct = $response.continuation_token
     } while ($parameters.ct)
 }

--- a/Cmdlets/Public/Get-TeamViewerUserByRole.ps1
+++ b/Cmdlets/Public/Get-TeamViewerUserByRole.ps1
@@ -1,4 +1,6 @@
 function Get-TeamViewerUserByRole {
+    [CmdletBinding()]
+
     param(
         [Parameter(Mandatory = $true)]
         [securestring]
@@ -14,6 +16,7 @@ function Get-TeamViewerUserByRole {
 
     $resourceUri = "$(Get-TeamViewerApiUri)/userroles/assignments/account?userRoleId=$RoleId"
     $parameters = $null
+
     do {
         $response = Invoke-TeamViewerRestMethod `
             -ApiToken $ApiToken `
@@ -22,9 +25,11 @@ function Get-TeamViewerUserByRole {
             -Body $parameters `
             -WriteErrorTo $PSCmdlet `
             -ErrorAction Stop
+
         if ($response.ContinuationToken) {
             $resourceUri += '&continuationToken=' + $response.ContinuationToken
         }
+
         Write-Output ($response.AssignedToUsers | ConvertTo-TeamViewerRoleAssignedUser )
     }while ($response.ContinuationToken)
 }

--- a/Cmdlets/Public/Get-TeamViewerUserGroup.ps1
+++ b/Cmdlets/Public/Get-TeamViewerUserGroup.ps1
@@ -1,4 +1,6 @@
 function Get-TeamViewerUserGroup {
+    [CmdletBinding()]
+
     param(
         [Parameter(Mandatory = $true)]
         [securestring]
@@ -6,13 +8,13 @@ function Get-TeamViewerUserGroup {
 
         [Parameter()]
         [ValidateScript( { $_ | Resolve-TeamViewerUserGroupId } )]
-        [Alias("UserGroupId")]
-        [Alias("Id")]
+        [Alias('UserGroupId')]
+        [Alias('Id')]
         [object]
         $UserGroup
     )
 
-    Begin {
+    begin {
         $resourceUri = "$(Get-TeamViewerApiUri)/usergroups"
         $parameters = @{ }
         $isListOperation = $true
@@ -25,7 +27,7 @@ function Get-TeamViewerUserGroup {
         }
     }
 
-    Process {
+    process {
         do {
             $response = Invoke-TeamViewerRestMethod `
                 -ApiToken $ApiToken `
@@ -34,6 +36,7 @@ function Get-TeamViewerUserGroup {
                 -Body $parameters `
                 -WriteErrorTo $PSCmdlet `
                 -ErrorAction Stop
+
             if ($UserGroup) {
                 Write-Output ($response | ConvertTo-TeamViewerUserGroup)
             }
@@ -41,6 +44,6 @@ function Get-TeamViewerUserGroup {
                 $parameters.paginationToken = $response.nextPaginationToken
                 Write-Output ($response.resources | ConvertTo-TeamViewerUserGroup)
             }
-        } while ($isListOperation -And $parameters.paginationToken)
+        } while ($isListOperation -and $parameters.paginationToken)
     }
 }

--- a/Cmdlets/Public/Get-TeamViewerUserGroupByRole.ps1
+++ b/Cmdlets/Public/Get-TeamViewerUserGroupByRole.ps1
@@ -1,4 +1,6 @@
 function Get-TeamViewerUserGroupByRole {
+    [CmdletBinding()]
+
     param(
         [Parameter(Mandatory = $true)]
         [securestring]
@@ -11,11 +13,12 @@ function Get-TeamViewerUserGroupByRole {
         $RoleId
     )
 
-    Begin {
+    begin {
         $resourceUri = "$(Get-TeamViewerApiUri)/userroles/assignments/usergroups?userRoleId=$RoleId"
         $parameters = $null
     }
-    Process {
+
+    process {
         do {
             $response = Invoke-TeamViewerRestMethod `
                 -ApiToken $ApiToken `
@@ -24,9 +27,11 @@ function Get-TeamViewerUserGroupByRole {
                 -Body $parameters `
                 -WriteErrorTo $PSCmdlet `
                 -ErrorAction Stop
+
             if ($response.ContinuationToken) {
                 $resourceUri += '&continuationToken=' + $response.ContinuationToken
             }
+
             Write-Output ($response.AssignedToGroups | ConvertTo-TeamViewerRoleAssignedUserGroup )
         }while ($response.ContinuationToken)
     }

--- a/Cmdlets/Public/Get-TeamViewerVersion.ps1
+++ b/Cmdlets/Public/Get-TeamViewerVersion.ps1
@@ -1,4 +1,8 @@
 function Get-TeamViewerVersion {
+    [CmdletBinding()]
+
+    param()
+
     if (Test-TeamViewerInstallation) {
         return (Get-ItemPropertyValue -Path (Get-TeamViewerRegKeyPath) -Name 'Version')
     }

--- a/Cmdlets/Public/Invoke-TeamViewerPackageDownload.ps1
+++ b/Cmdlets/Public/Invoke-TeamViewerPackageDownload.ps1
@@ -1,5 +1,7 @@
 function Invoke-TeamViewerPackageDownload {
-    Param(
+    [CmdletBinding()]
+
+    param(
         [Parameter()]
         [ValidateSet('Full', 'Host', 'MSI32', 'MSI64', 'Portable', 'QuickJoin', 'QuickSupport', 'Full64Bit')]
         [string]
@@ -7,15 +9,15 @@ function Invoke-TeamViewerPackageDownload {
 
         [Parameter()]
         [ValidateScript( {
-                if($PackageType -eq 'MSI32' -or 'MSI64' ){
+                if ($PackageType -eq 'MSI32' -or 'MSI64' ) {
                     $PSCmdlet.ThrowTerminatingError(
-                        ("MajorVersion parameter is not supported for MSI packages" | `
-                                ConvertTo-ErrorRecord -ErrorCategory InvalidArgument))
+                        ('MajorVersion parameter is not supported for MSI packages' | `
+                            ConvertTo-ErrorRecord -ErrorCategory InvalidArgument))
                 }
                 if ($_ -lt 14) {
                     $PSCmdlet.ThrowTerminatingError(
                         ("Unsupported TeamViewer version $_" | `
-                                ConvertTo-ErrorRecord -ErrorCategory InvalidArgument))
+                            ConvertTo-ErrorRecord -ErrorCategory InvalidArgument))
                 }
                 $true
             } )]
@@ -39,32 +41,52 @@ function Invoke-TeamViewerPackageDownload {
 
     $additionalPath = ''
     $filename = switch ($PackageType) {
-        'Full' { 'TeamViewer_Setup.exe' }
-        'MSI32' { 'TeamViewer_MSI32.zip' }
-        'MSI64' { 'TeamViewer_MSI64.zip' }
-        'Host' { 'TeamViewer_Host_Setup.exe' }
-        'Portable' { 'TeamViewerPortable.zip' }
-        'QuickJoin' { 'TeamViewerQJ.exe' }
-        'QuickSupport' { 'TeamViewerQS.exe' }
-        'Full64Bit' { 'TeamViewer_Setup_x64.exe' }
+        'Full' {
+            'TeamViewer_Setup.exe'
+        }
+        'MSI32' {
+            'TeamViewer_MSI32.zip'
+        }
+        'MSI64' {
+            'TeamViewer_MSI64.zip'
+        }
+        'Host' {
+            'TeamViewer_Host_Setup.exe'
+        }
+        'Portable' {
+            'TeamViewerPortable.zip'
+        }
+        'QuickJoin' {
+            'TeamViewerQJ.exe'
+        }
+        'QuickSupport' {
+            'TeamViewerQS.exe'
+        }
+        'Full64Bit' {
+            'TeamViewer_Setup_x64.exe'
+        }
     }
+
     if ($MajorVersion) {
         $additionalPath = "/version_$($MajorVersion)x"
     }
-    if(($PackageType -eq 'MSI32' -or 'MSI64' )){
+
+    if (($PackageType -eq 'MSI32' -or 'MSI64' )) {
         $additionalPath = '/version_15x'
     }
 
     $downloadUrl = "https://dl.teamviewer.com/download$additionalPath/$filename"
     $targetFile = Join-Path $TargetDirectory $filename
 
-    if ((Test-Path $targetFile) -And -Not $Force -And `
-            -Not $PSCmdlet.ShouldContinue("File $targetFile already exists. Override?", "Override existing file?")) {
+    if ((Test-Path $targetFile) -and -not $Force -and `
+            -not $PSCmdlet.ShouldContinue("File $targetFile already exists. Override?", 'Override existing file?')) {
         return
     }
 
     Write-Verbose "Downloading $downloadUrl to $targetFile"
+
     $client = New-Object System.Net.WebClient
     $client.DownloadFile($downloadUrl, $targetFile)
+
     Write-Output $targetFile
 }

--- a/Cmdlets/Public/Invoke-TeamViewerPing.ps1
+++ b/Cmdlets/Public/Invoke-TeamViewerPing.ps1
@@ -1,4 +1,6 @@
 function Invoke-TeamViewerPing {
+    [CmdletBinding()]
+
     param(
         [Parameter(Mandatory = $true)]
         [securestring]
@@ -12,5 +14,6 @@ function Invoke-TeamViewerPing {
         -Method Get `
         -WriteErrorTo $PSCmdlet `
         -ErrorAction Stop
+
     Write-Output $result.token_valid
 }

--- a/Cmdlets/Public/Test-TeamViewerInstallation.ps1
+++ b/Cmdlets/Public/Test-TeamViewerInstallation.ps1
@@ -1,4 +1,8 @@
 function Test-TeamViewerInstallation {
+    [CmdletBinding()]
+
+    param()
+
     if (Get-TeamViewerInstallationDirectory) {
         return $true
     }


### PR DESCRIPTION
## Summary

Standardize `CmdletBinding` usage across all public TeamViewerPS cmdlets and document the convention for future contributions.

- Add plain `[CmdletBinding()]` to public cmdlets that were missing it.
- Add required empty `param()` blocks to parameterless advanced functions.
- Preserve existing `SupportsShouldProcess` behavior for mutating cmdlets.
- Document the public/private CmdletBinding rules in `AGENTS.md`.
- Update the unreleased changelog entry.

## Validation

- PSScriptAnalyzer passed.
- Pester passed: 729 tests.