### PR TITLE
Document pipeline lifecycle block usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ Invoke-Build -Task Test
 - Preserve public function names and parameter contracts unless explicitly asked to change them.
 - Prefer existing helpers in `Cmdlets/Private` over new abstractions.
 - Follow naming conventions: `ConvertTo-*` for mapping, `Resolve-*` for lookups
+- **Pipeline Lifecycle Blocks**: Use `begin`, `process`, and `end` blocks only when their pipeline lifecycle semantics are needed. Handle pipeline parameters in `process`, initialize shared state in `begin`, and flush accumulated or final work in `end`. Do not add empty or ceremonial blocks to scalar-only commands.
 - **Pipeline Output Pattern**: Process blocks must use implicit pipeline emission (no `return` or `Write-Output`); non-pipeline functions use explicit `return` statements. This standardizes when values enter the pipeline vs. are explicitly returned.
 - Add or update Pester tests for every behavior change; include a regression test for bug fixes.
 - Run lint and tests before finishing; both must pass.

--- a/Cmdlets/Public/Remove-TeamViewerManagedDevice.ps1
+++ b/Cmdlets/Public/Remove-TeamViewerManagedDevice.ps1
@@ -21,18 +21,18 @@ function Remove-TeamViewerManagedDevice {
 
     begin {
         $groupId = $Group | Resolve-TeamViewerManagedGroupId
+        $deviceId = $Device | Resolve-TeamViewerManagedDeviceId
+        $resourceUri = "$(Get-TeamViewerApiUri)/managed/groups/$groupId/devices/$deviceId"
     }
 
     process {
-        $deviceId = $Device | Resolve-TeamViewerManagedDeviceId
-        $resourceUri = "$(Get-TeamViewerApiUri)/managed/groups/$groupId/devices/$deviceId"
-
         if ($PSCmdlet.ShouldProcess($deviceId, 'Remove device from managed group')) {
             Invoke-TeamViewerRestMethod `
                 -ApiToken $ApiToken `
                 -Uri $resourceUri `
                 -Method Delete `
-                -WriteErrorTo $PSCmdlet | Out-Null
+                -WriteErrorTo $PSCmdlet | `
+                Out-Null
         }
     }
 }

--- a/Cmdlets/Public/Remove-TeamViewerManagedDevice.ps1
+++ b/Cmdlets/Public/Remove-TeamViewerManagedDevice.ps1
@@ -1,5 +1,6 @@
 function Remove-TeamViewerManagedDevice {
     [CmdletBinding(SupportsShouldProcess = $true)]
+
     param(
         [Parameter(Mandatory = $true)]
         [securestring]
@@ -7,29 +8,31 @@ function Remove-TeamViewerManagedDevice {
 
         [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
         [ValidateScript( { $_ | Resolve-TeamViewerManagedDeviceId } )]
-        [Alias("DeviceId")]
+        [Alias('DeviceId')]
         [object]
         $Device,
 
         [Parameter(Mandatory = $true)]
         [ValidateScript( { $_ | Resolve-TeamViewerManagedGroupId } )]
-        [Alias("GroupId")]
+        [Alias('GroupId')]
         [object]
         $Group
     )
-    Process {
-        $deviceId = $Device | Resolve-TeamViewerManagedDeviceId
-        $groupId = $Group | Resolve-TeamViewerManagedGroupId
 
+    begin {
+        $groupId = $Group | Resolve-TeamViewerManagedGroupId
+    }
+
+    process {
+        $deviceId = $Device | Resolve-TeamViewerManagedDeviceId
         $resourceUri = "$(Get-TeamViewerApiUri)/managed/groups/$groupId/devices/$deviceId"
 
-        if ($PSCmdlet.ShouldProcess($deviceId, "Remove device from managed group")) {
+        if ($PSCmdlet.ShouldProcess($deviceId, 'Remove device from managed group')) {
             Invoke-TeamViewerRestMethod `
                 -ApiToken $ApiToken `
                 -Uri $resourceUri `
                 -Method Delete `
-                -WriteErrorTo $PSCmdlet | `
-                Out-Null
+                -WriteErrorTo $PSCmdlet | Out-Null
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add lifecycle-block guidance to `AGENTS.md`.
- Resolve the invariant managed-group ID once in `begin`.
- Keep per-device resolution and deletion in `process`.

## Validation
- PSScriptAnalyzer passed.
- Pester passed: 729 tests.