### PR TITLE
Add parameter validation to public cmdlets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ Invoke-Build -Task Test
 - Preserve public function names and parameter contracts unless explicitly asked to change them.
 - Prefer existing helpers in `Cmdlets/Private` over new abstractions.
 - Follow naming conventions: `ConvertTo-*` for mapping, `Resolve-*` for lookups
+- **Parameter Validation**: Use validation attributes when a parameter has a stable finite set, numeric range, required format, or existing resolver. Prefer `ValidateSet`, `ValidateRange`, and `ValidateScript` at the parameter boundary; do not add constraints that reject otherwise valid API values.
 - **Pipeline Output Pattern**: Process blocks must use implicit pipeline emission (no `return` or `Write-Output`); non-pipeline functions use explicit `return` statements. This standardizes when values enter the pipeline vs. are explicitly returned.
 - Add or update Pester tests for every behavior change; include a regression test for bug fixes.
 - Run lint and tests before finishing; both must pass.

--- a/Cmdlets/Public/Add-TeamViewerAssignment.ps1
+++ b/Cmdlets/Public/Add-TeamViewerAssignment.ps1
@@ -9,6 +9,7 @@ function Add-TeamViewerAssignment {
         [string]
         $DeviceAlias,
 
+        [ValidateRange(1, [int]::MaxValue)]
         [int]
         $Retries
     )

--- a/Cmdlets/Public/Get-TeamViewerConnectionReport.ps1
+++ b/Cmdlets/Public/Get-TeamViewerConnectionReport.ps1
@@ -1,5 +1,6 @@
 function Get-TeamViewerConnectionReport {
     [CmdletBinding()]
+
     param(
         [Parameter(Mandatory = $true)]
         [securestring]
@@ -11,13 +12,13 @@ function Get-TeamViewerConnectionReport {
 
         [Parameter(Mandatory = $false)]
         [ValidateScript( { $_ | Resolve-TeamViewerUserId } )]
-        [Alias("User")]
+        [Alias('User')]
         [object]
         $UserId,
 
         [Parameter(Mandatory = $false)]
         [ValidateScript( { $_ | Resolve-TeamViewerGroupId } )]
-        [Alias("Group")]
+        [Alias('Group')]
         [object]
         $GroupId,
 
@@ -26,6 +27,7 @@ function Get-TeamViewerConnectionReport {
         $DeviceName,
 
         [Parameter(Mandatory = $false)]
+        [ValidateRange(1, [int]::MaxValue)]
         [int]
         $DeviceId,
 
@@ -45,31 +47,31 @@ function Get-TeamViewerConnectionReport {
         [TeamViewerConnectionReportSessionType]
         $SupportSessionType,
 
-        [Parameter(Mandatory = $true, ParameterSetName = "AbsoluteDates")]
+        [Parameter(Mandatory = $true, ParameterSetName = 'AbsoluteDates')]
         [DateTime]
         $StartDate,
 
-        [Parameter(Mandatory = $false, ParameterSetName = "AbsoluteDates")]
-        [Parameter(Mandatory = $false, ParameterSetName = "RelativeDates")]
+        [Parameter(Mandatory = $false, ParameterSetName = 'AbsoluteDates')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'RelativeDates')]
         [DateTime]
         $EndDate = (Get-Date),
 
-        [Parameter(Mandatory = $false, ParameterSetName = "RelativeDates")]
+        [Parameter(Mandatory = $false, ParameterSetName = 'RelativeDates')]
         [ValidateRange(0, 12)]
         [int]
         $Months,
 
-        [Parameter(Mandatory = $false, ParameterSetName = "RelativeDates")]
+        [Parameter(Mandatory = $false, ParameterSetName = 'RelativeDates')]
         [ValidateRange(0, 31)]
         [int]
         $Days,
 
-        [Parameter(Mandatory = $false, ParameterSetName = "RelativeDates")]
+        [Parameter(Mandatory = $false, ParameterSetName = 'RelativeDates')]
         [ValidateRange(0, 24)]
         [int]
         $Hours,
 
-        [Parameter(Mandatory = $false, ParameterSetName = "RelativeDates")]
+        [Parameter(Mandatory = $false, ParameterSetName = 'RelativeDates')]
         [ValidateRange(0, 60)]
         [int]
         $Minutes,
@@ -80,16 +82,16 @@ function Get-TeamViewerConnectionReport {
         $Limit
     )
 
-    $resourceUri = "$(Get-TeamViewerApiUri)/reports/connections";
+    $resourceUri = "$(Get-TeamViewerApiUri)/reports/connections"
 
     $parameters = @{}
 
-    if ($PSCmdlet.ParameterSetName -Eq 'RelativeDates') {
+    if ($PSCmdlet.ParameterSetName -eq 'RelativeDates') {
         $StartDate = $EndDate.AddMonths(-1 * $Months).AddDays(-1 * $Days).AddHours(-1 * $Hours).AddMinutes(-1 * $Minutes)
     }
-    if ($StartDate -And $EndDate -And $StartDate -lt $EndDate) {
-        $parameters.from_date = $StartDate.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
-        $parameters.to_date = $EndDate.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+    if ($StartDate -and $EndDate -and $StartDate -lt $EndDate) {
+        $parameters.from_date = $StartDate.ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+        $parameters.to_date = $EndDate.ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
     }
 
     if ($UserName) {
@@ -112,10 +114,10 @@ function Get-TeamViewerConnectionReport {
         $parameters.groupid = $GroupId | Resolve-TeamViewerGroupId
     }
 
-    if ($WithSessionCode -And !$WithoutSessionCode) {
+    if ($WithSessionCode -and !$WithoutSessionCode) {
         $parameters.has_code = $true
     }
-    elseif ($WithoutSessionCode -And !$WithSessionCode) {
+    elseif ($WithoutSessionCode -and !$WithSessionCode) {
         $parameters.has_code = $false
     }
 
@@ -145,5 +147,5 @@ function Get-TeamViewerConnectionReport {
             Write-Output $results
         }
         $parameters.offset_id = $response.next_offset
-    } while ($parameters.offset_id -And (!$Limit -Or $remaining -gt 0))
+    } while ($parameters.offset_id -and (!$Limit -or $remaining -gt 0))
 }

--- a/Cmdlets/Public/Get-TeamViewerDevice.ps1
+++ b/Cmdlets/Public/Get-TeamViewerDevice.ps1
@@ -1,33 +1,35 @@
 function Get-TeamViewerDevice {
-    [CmdletBinding(DefaultParameterSetName = "FilteredList")]
+    [CmdletBinding(DefaultParameterSetName = 'FilteredList')]
+
     param(
         [Parameter(Mandatory = $true)]
         [securestring]
         $ApiToken,
 
-        [Parameter(ParameterSetName = "ByDeviceId")]
+        [Parameter(ParameterSetName = 'ByDeviceId')]
         [ValidateScript( { $_ | Resolve-TeamViewerDeviceId } )]
-        [Alias("DeviceId")]
+        [Alias('DeviceId')]
         [string]
         $Id,
 
-        [Parameter(ParameterSetName = "FilteredList")]
+        [Parameter(ParameterSetName = 'FilteredList')]
+        [ValidateRange(1, [int]::MaxValue)]
         [int]
         $TeamViewerId,
 
-        [Parameter(ParameterSetName = "FilteredList")]
+        [Parameter(ParameterSetName = 'FilteredList')]
         [ValidateSet('Online', 'Busy', 'Away', 'Offline')]
         [string]
         $FilterOnlineState,
 
-        [Parameter(ParameterSetName = "FilteredList")]
+        [Parameter(ParameterSetName = 'FilteredList')]
         [ValidateScript( { $_ | Resolve-TeamViewerGroupId } )]
-        [Alias("GroupId")]
+        [Alias('GroupId')]
         [object]
         $Group
     )
 
-    $resourceUri = "$(Get-TeamViewerApiUri)/devices";
+    $resourceUri = "$(Get-TeamViewerApiUri)/devices"
     $parameters = @{ }
 
     switch ($PsCmdlet.ParameterSetName) {

--- a/Cmdlets/Public/Get-TeamViewerEventLog.ps1
+++ b/Cmdlets/Public/Get-TeamViewerEventLog.ps1
@@ -1,40 +1,42 @@
 function Get-TeamViewerEventLog {
-    [CmdletBinding(DefaultParameterSetName = "RelativeDates")]
+    [CmdletBinding(DefaultParameterSetName = 'RelativeDates')]
+
     param(
         [Parameter(Mandatory = $true)]
         [securestring]
         $ApiToken,
 
-        [Parameter(Mandatory = $true, ParameterSetName = "AbsoluteDates")]
+        [Parameter(Mandatory = $true, ParameterSetName = 'AbsoluteDates')]
         [DateTime]
         $StartDate,
 
-        [Parameter(Mandatory = $false, ParameterSetName = "AbsoluteDates")]
-        [Parameter(Mandatory = $false, ParameterSetName = "RelativeDates")]
+        [Parameter(Mandatory = $false, ParameterSetName = 'AbsoluteDates')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'RelativeDates')]
         [DateTime]
         $EndDate = (Get-Date),
 
-        [Parameter(Mandatory = $false, ParameterSetName = "RelativeDates")]
+        [Parameter(Mandatory = $false, ParameterSetName = 'RelativeDates')]
         [ValidateRange(0, 12)]
         [int]
         $Months,
 
-        [Parameter(Mandatory = $false, ParameterSetName = "RelativeDates")]
+        [Parameter(Mandatory = $false, ParameterSetName = 'RelativeDates')]
         [ValidateRange(0, 31)]
         [int]
         $Days,
 
-        [Parameter(Mandatory = $false, ParameterSetName = "RelativeDates")]
+        [Parameter(Mandatory = $false, ParameterSetName = 'RelativeDates')]
         [ValidateRange(0, 24)]
         [int]
         $Hours,
 
-        [Parameter(Mandatory = $false, ParameterSetName = "RelativeDates")]
+        [Parameter(Mandatory = $false, ParameterSetName = 'RelativeDates')]
         [ValidateRange(0, 60)]
         [int]
         $Minutes,
 
         [Parameter(Mandatory = $false)]
+        [ValidateRange(0, [int]::MaxValue)]
         [int]
         $Limit,
 
@@ -113,16 +115,16 @@ function Get-TeamViewerEventLog {
                 param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
                 $null = @($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
                 @(
-                    "CompanyAddressBook",
-                    "CompanyAdministration",
-                    "ConditionalAccess",
-                    "CustomModules",
-                    "GroupManagement",
-                    "LicenseManagement",
-                    "Policy",
-                    "Session",
-                    "UserGroups",
-                    "UserProfile"
+                    'CompanyAddressBook',
+                    'CompanyAdministration',
+                    'ConditionalAccess',
+                    'CustomModules',
+                    'GroupManagement',
+                    'LicenseManagement',
+                    'Policy',
+                    'Session',
+                    'UserGroups',
+                    'UserProfile'
                 ) | Where-Object { $_ -like "$wordToComplete*" }
             })]
         [string[]]
@@ -130,7 +132,7 @@ function Get-TeamViewerEventLog {
 
         [Parameter(Mandatory = $false)]
         [ValidateScript( { $_ | Resolve-TeamViewerUserEmail } )]
-        [Alias("Users")]
+        [Alias('Users')]
         [object[]]
         $AccountEmails,
 
@@ -139,23 +141,33 @@ function Get-TeamViewerEventLog {
         $AffectedItem,
 
         [Parameter(Mandatory = $false)]
-        [Alias("RemoteControlSession")]
+        [Alias('RemoteControlSession')]
         [guid]
         $RemoteControlSessionId
     )
 
-    $resourceUri = "$(Get-TeamViewerApiUri)/EventLogging";
+    $resourceUri = "$(Get-TeamViewerApiUri)/EventLogging"
 
-    $Limit = if ($Limit -lt 0) { $null } else { $Limit }
+    $Limit = if ($Limit -lt 0) {
+        $null 
+    }
+    else {
+        $Limit 
+    }
 
-    if ($PSCmdlet.ParameterSetName -Eq 'RelativeDates') {
-        $Hours = if (!$Months -And !$Days -And !$Hours -And !$Minutes) { 1 } else { $Hours }
+    if ($PSCmdlet.ParameterSetName -eq 'RelativeDates') {
+        $Hours = if (!$Months -and !$Days -and !$Hours -and !$Minutes) {
+            1 
+        }
+        else {
+            $Hours 
+        }
         $StartDate = $EndDate.AddMonths(-1 * $Months).AddDays(-1 * $Days).AddHours(-1 * $Hours).AddMinutes(-1 * $Minutes)
     }
 
     $parameters = @{
-        StartDate = $StartDate.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
-        EndDate   = $EndDate.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+        StartDate = $StartDate.ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+        EndDate   = $EndDate.ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
     }
 
     if ($EventNames) {
@@ -180,7 +192,7 @@ function Get-TeamViewerEventLog {
             -ApiToken $ApiToken `
             -Uri $resourceUri `
             -Method Post `
-            -ContentType "application/json; charset=utf-8" `
+            -ContentType 'application/json; charset=utf-8' `
             -Body ([System.Text.Encoding]::UTF8.GetBytes(($parameters | ConvertTo-Json))) `
             -WriteErrorTo $PSCmdlet `
             -ErrorAction Stop
@@ -193,5 +205,5 @@ function Get-TeamViewerEventLog {
             Write-Output $results
         }
         $parameters.ContinuationToken = $response.ContinuationToken
-    } while ($parameters.ContinuationToken -And (!$Limit -Or $remaining -gt 0))
+    } while ($parameters.ContinuationToken -and (!$Limit -or $remaining -gt 0))
 }

--- a/Cmdlets/Public/Invoke-TeamViewerPackageDownload.ps1
+++ b/Cmdlets/Public/Invoke-TeamViewerPackageDownload.ps1
@@ -1,5 +1,5 @@
 function Invoke-TeamViewerPackageDownload {
-    Param(
+    param(
         [Parameter()]
         [ValidateSet('Full', 'Host', 'MSI32', 'MSI64', 'Portable', 'QuickJoin', 'QuickSupport', 'Full64Bit')]
         [string]
@@ -7,15 +7,15 @@ function Invoke-TeamViewerPackageDownload {
 
         [Parameter()]
         [ValidateScript( {
-                if($PackageType -eq 'MSI32' -or 'MSI64' ){
+                if ($PackageType -eq 'MSI32' -or $PackageType -eq 'MSI64') {
                     $PSCmdlet.ThrowTerminatingError(
-                        ("MajorVersion parameter is not supported for MSI packages" | `
-                                ConvertTo-ErrorRecord -ErrorCategory InvalidArgument))
+                        ('MajorVersion parameter is not supported for MSI packages' | `
+                            ConvertTo-ErrorRecord -ErrorCategory InvalidArgument))
                 }
-                if ($_ -lt 14) {
+                if ($_ -ne 0 -and $_ -lt 14) {
                     $PSCmdlet.ThrowTerminatingError(
                         ("Unsupported TeamViewer version $_" | `
-                                ConvertTo-ErrorRecord -ErrorCategory InvalidArgument))
+                            ConvertTo-ErrorRecord -ErrorCategory InvalidArgument))
                 }
                 $true
             } )]
@@ -23,6 +23,7 @@ function Invoke-TeamViewerPackageDownload {
         $MajorVersion,
 
         [Parameter()]
+        [ValidateScript({ Test-Path -LiteralPath $_ -PathType Container })]
         [string]
         $TargetDirectory = (Get-Location).Path,
 
@@ -39,32 +40,49 @@ function Invoke-TeamViewerPackageDownload {
 
     $additionalPath = ''
     $filename = switch ($PackageType) {
-        'Full' { 'TeamViewer_Setup.exe' }
-        'MSI32' { 'TeamViewer_MSI32.zip' }
-        'MSI64' { 'TeamViewer_MSI64.zip' }
-        'Host' { 'TeamViewer_Host_Setup.exe' }
-        'Portable' { 'TeamViewerPortable.zip' }
-        'QuickJoin' { 'TeamViewerQJ.exe' }
-        'QuickSupport' { 'TeamViewerQS.exe' }
-        'Full64Bit' { 'TeamViewer_Setup_x64.exe' }
+        'Full' {
+            'TeamViewer_Setup.exe'
+        }
+        'MSI32' {
+            'TeamViewer_MSI32.zip'
+        }
+        'MSI64' {
+            'TeamViewer_MSI64.zip'
+        }
+        'Host' {
+            'TeamViewer_Host_Setup.exe'
+        }
+        'Portable' {
+            'TeamViewerPortable.zip'
+        }
+        'QuickJoin' {
+            'TeamViewerQJ.exe'
+        }
+        'QuickSupport' {
+            'TeamViewerQS.exe'
+        }
+        'Full64Bit' {
+            'TeamViewer_Setup_x64.exe'
+        }
     }
     if ($MajorVersion) {
         $additionalPath = "/version_$($MajorVersion)x"
     }
-    if(($PackageType -eq 'MSI32' -or 'MSI64' )){
+    if (($PackageType -eq 'MSI32' -or 'MSI64' )) {
         $additionalPath = '/version_15x'
     }
 
     $downloadUrl = "https://dl.teamviewer.com/download$additionalPath/$filename"
     $targetFile = Join-Path $TargetDirectory $filename
 
-    if ((Test-Path $targetFile) -And -Not $Force -And `
-            -Not $PSCmdlet.ShouldContinue("File $targetFile already exists. Override?", "Override existing file?")) {
+    if ((Test-Path $targetFile) -and -not $Force -and `
+            -not $PSCmdlet.ShouldContinue("File $targetFile already exists. Override?", 'Override existing file?')) {
         return
     }
 
     Write-Verbose "Downloading $downloadUrl to $targetFile"
     $client = New-Object System.Net.WebClient
     $client.DownloadFile($downloadUrl, $targetFile)
+
     Write-Output $targetFile
 }

--- a/Cmdlets/Public/New-TeamViewerDevice.ps1
+++ b/Cmdlets/Public/New-TeamViewerDevice.ps1
@@ -1,22 +1,24 @@
 function New-TeamViewerDevice {
     [CmdletBinding(SupportsShouldProcess = $true)]
+
     param(
         [Parameter(Mandatory = $true)]
         [securestring]
         $ApiToken,
 
         [Parameter(Mandatory = $true)]
+        [ValidateRange(1, [int]::MaxValue)]
         [int]
         $TeamViewerId,
 
         [Parameter(Mandatory = $true)]
         [ValidateScript( { $_ | Resolve-TeamViewerGroupId } )]
-        [Alias("GroupId")]
+        [Alias('GroupId')]
         [object]
         $Group,
 
         [Parameter()]
-        [Alias("Alias")]
+        [Alias('Alias')]
         [string]
         $Name,
 
@@ -37,9 +39,11 @@ function New-TeamViewerDevice {
     if ($Name) {
         $body['alias'] = $Name
     }
+
     if ($Description) {
         $body['description'] = $Description
     }
+
     if ($Password) {
         $bstr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($Password)
         $body['password'] = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($bstr)
@@ -47,17 +51,18 @@ function New-TeamViewerDevice {
     }
 
     $resourceUri = "$(Get-TeamViewerApiUri)/devices"
-    if ($PSCmdlet.ShouldProcess($TeamViewerId, "Create device entry")) {
+    if ($PSCmdlet.ShouldProcess($TeamViewerId, 'Create device entry')) {
         $response = Invoke-TeamViewerRestMethod `
             -ApiToken $ApiToken `
             -Uri $resourceUri `
             -Method Post `
-            -ContentType "application/json; charset=utf-8" `
+            -ContentType 'application/json; charset=utf-8' `
             -Body ([System.Text.Encoding]::UTF8.GetBytes(($body | ConvertTo-Json))) `
             -WriteErrorTo $PSCmdlet `
             -ErrorAction Stop
 
         $result = ($response | ConvertTo-TeamViewerDevice)
+
         Write-Output $result
     }
 }

--- a/Tests/Public/Add-TeamViewerAssignment.Tests.ps1
+++ b/Tests/Public/Add-TeamViewerAssignment.Tests.ps1
@@ -16,6 +16,10 @@ Describe 'Add-TeamViewerAssignment' {
         }
     }
 
+    It 'Should reject a non-positive retry count' {
+        { Add-TeamViewerAssignment -AssignmentId '123' -Retries 0 } | Should -Throw
+    }
+
     It 'Should call TeamViewer.exe assignment with device alias and retries' {
         Mock Start-Process -ParameterFilter {
             $FilePath -eq (Join-Path -Path 'testPath' -ChildPath 'TeamViewer.exe') -and

--- a/Tests/Public/Get-TeamViewerConnectionReport.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerConnectionReport.Tests.ps1
@@ -2,8 +2,7 @@ BeforeAll {
     . "$PSScriptRoot\..\..\Cmdlets\TeamViewerPS.Types.ps1"
     . "$PSScriptRoot\..\..\Cmdlets\Public\Get-TeamViewerConnectionReport.ps1"
 
-    @(Get-ChildItem -Path "$PSScriptRoot\..\..\Cmdlets\Private\*.ps1") | `
-        ForEach-Object { . $_.FullName }
+    @(Get-ChildItem -Path "$PSScriptRoot\..\..\Cmdlets\Private\*.ps1") | ForEach-Object { . $_.FullName }
 
     $testApiToken = [securestring]@{}
     $null = $testApiToken
@@ -36,11 +35,16 @@ BeforeAll {
 }
 
 Describe 'Get-TeamViewerConnectionReport' {
+    It 'Should reject a non-positive device ID' {
+        { Get-TeamViewerConnectionReport -ApiToken $testApiToken -DeviceId 0 } | Should -Throw
+    }
+
     It 'Should call the correct API endpoint to list connection reports' {
         Get-TeamViewerConnectionReport -ApiToken $testApiToken
+
         Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
-            $ApiToken -eq $testApiToken -And `
-                $Uri -eq '//unit.test/reports/connections' -And `
+            $ApiToken -eq $testApiToken -and `
+                $Uri -eq '//unit.test/reports/connections' -and `
                 $Method -eq 'Get' }
     }
 
@@ -66,6 +70,7 @@ Describe 'Get-TeamViewerConnectionReport' {
                 )
                 next_offset = '0755a8dd-df19-4ea7-af47-cabb6b2a97e4'
             } }
+
         Mock Invoke-TeamViewerRestMethod { @{
                 records     = @(
                     @{
@@ -81,7 +86,8 @@ Describe 'Get-TeamViewerConnectionReport' {
                 )
                 next_offset = '5ae6d2a9-57e9-4c62-b236-280390954b6f'
             } } -ParameterFilter { $Body.offset_id -eq '0755a8dd-df19-4ea7-af47-cabb6b2a97e4' }
-	        Mock Invoke-TeamViewerRestMethod { @{
+
+        Mock Invoke-TeamViewerRestMethod { @{
                 records = @(
                     @{
                         id                   = '018d007c-9faf-474a-b39a-4021251860e7'
@@ -94,11 +100,12 @@ Describe 'Get-TeamViewerConnectionReport' {
                         support_session_type = 1
                     }
                 )
-            } }  -ParameterFilter { $Body.offset_id -eq '5ae6d2a9-57e9-4c62-b236-280390954b6f' }
+            } } -ParameterFilter { $Body.offset_id -eq '5ae6d2a9-57e9-4c62-b236-280390954b6f' }
 
 
         $result = Get-TeamViewerConnectionReport -ApiToken $testApiToken
         $result | Should -HaveCount 3
+
         Should -Invoke Invoke-TeamViewerRestMethod -Times 3 -Scope It
     }
 
@@ -110,54 +117,63 @@ Describe 'Get-TeamViewerConnectionReport' {
 
         It 'Should allow to filter by username' {
             Get-TeamViewerConnectionReport -ApiToken $testApiToken -UserName 'test-user1'
+
             Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It
             $mockArgs.Body.username | Should -Be 'test-user1'
         }
 
         It 'Should allow to filter by userid' {
             Get-TeamViewerConnectionReport -ApiToken $testApiToken -UserId 'u1234'
+
             Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It
             $mockArgs.Body.userid | Should -Be 'u1234'
         }
 
         It 'Should allow to filter by groupid' {
             Get-TeamViewerConnectionReport -ApiToken $testApiToken -GroupId 'g1234'
+
             Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It
             $mockArgs.Body.groupid | Should -Be 'g1234'
         }
 
         It 'Should allow to filter by device name' {
             Get-TeamViewerConnectionReport -ApiToken $testApiToken -DeviceName 'test-device1'
+
             Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It
             $mockArgs.Body.devicename | Should -Be 'test-device1'
         }
 
         It 'Should allow to filter by deviceid' {
             Get-TeamViewerConnectionReport -ApiToken $testApiToken -DeviceId 111
+
             Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It
             $mockArgs.Body.deviceid | Should -Be '111'
         }
 
         It 'Should allow to filter by session code' {
             Get-TeamViewerConnectionReport -ApiToken $testApiToken -SessionCode 's112233'
+
             Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It
             $mockArgs.Body.session_code | Should -Be 's112233'
         }
 
         It 'Should allow to filter for entries with session code' {
             Get-TeamViewerConnectionReport -ApiToken $testApiToken -WithSessionCode
+
             Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It
             $mockArgs.Body.has_code | Should -Be $true
         }
 
         It 'Should allow to filter for entries without session code' {
             Get-TeamViewerConnectionReport -ApiToken $testApiToken -WithoutSessionCode
+
             Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It
             $mockArgs.Body.has_code | Should -Be $false
         }
 
         It 'Should allow to filter by support session type' {
             Get-TeamViewerConnectionReport -ApiToken $testApiToken -SupportSessionType 'RemoteSupportActiveSdk'
+
             Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It
             $mockArgs.Body.support_session_type | Should -Be 3
         }
@@ -170,6 +186,7 @@ Describe 'Get-TeamViewerConnectionReport' {
             $null = $testEndDate
 
             $mockArgs = @{}
+
             Mock Invoke-TeamViewerRestMethod { $mockArgs.Body = $Body; @{ records = @() } }
 
             function Get-TestStartEndDate {
@@ -188,8 +205,8 @@ Describe 'Get-TeamViewerConnectionReport' {
         }
 
         It 'Should allow to specify an absolute start and end time' {
-            Get-TeamViewerConnectionReport -ApiToken $testApiToken `
-                -StartDate $testStartDate -EndDate $testEndDate
+            Get-TeamViewerConnectionReport -ApiToken $testApiToken -StartDate $testStartDate -EndDate $testEndDate
+
             $dates = Get-TestStartEndDate
             $dates.StartDate | Should -Be $testStartDate.AddTicks(-1 * ($testStartDate.Ticks % [TimeSpan]::TicksPerSecond))
             $dates.EndDate | Should -Be $testEndDate.AddTicks(-1 * ($testEndDate.Ticks % [TimeSpan]::TicksPerSecond))
@@ -197,6 +214,7 @@ Describe 'Get-TeamViewerConnectionReport' {
 
         It 'Should allow to set a start date months in the past' {
             Get-TeamViewerConnectionReport -ApiToken $testApiToken -Months 3
+
             $dates = Get-TestStartEndDate
             $dates.Diff.TotalDays | Should -BeLessOrEqual (3 * 31)
             $dates.Diff.TotalDays | Should -BeGreaterOrEqual (3 * 28)
@@ -204,24 +222,28 @@ Describe 'Get-TeamViewerConnectionReport' {
 
         It 'Should allow to set a start date days in the past' {
             Get-TeamViewerConnectionReport -ApiToken $testApiToken -Days 7
+
             $dates = Get-TestStartEndDate
             $dates.Diff.TotalDays | Should -Be 7
         }
 
         It 'Should allow to set a start date hours in the past' {
             Get-TeamViewerConnectionReport -ApiToken $testApiToken -Hours 12
+
             $dates = Get-TestStartEndDate
             $dates.Diff.TotalHours | Should -Be 12
         }
 
         It 'Should allow to set a start date minutes in the past' {
             Get-TeamViewerConnectionReport -ApiToken $testApiToken -Minutes 45
+
             $dates = Get-TestStartEndDate
             $dates.Diff.TotalMinutes | Should -Be 45
         }
 
         It 'Should not restrict timeframe if no start and end date are given' {
             Get-TeamViewerConnectionReport -ApiToken $testApiToken
+
             $body = $mockArgs.Body
             $body.from_date | Should -BeNullOrEmpty
             $body.to_date | Should -BeNullOrEmpty

--- a/Tests/Public/Get-TeamViewerDevice.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerDevice.Tests.ps1
@@ -1,8 +1,7 @@
 BeforeAll {
     . "$PSScriptRoot\..\..\Cmdlets\Public\Get-TeamViewerDevice.ps1"
 
-    @(Get-ChildItem -Path "$PSScriptRoot\..\..\Cmdlets\Private\*.ps1") | `
-        ForEach-Object { . $_.FullName }
+    @(Get-ChildItem -Path "$PSScriptRoot\..\..\Cmdlets\Private\*.ps1") | ForEach-Object { . $_.FullName }
 
     $testApiToken = [securestring]@{}
     $null = $testApiToken
@@ -18,19 +17,25 @@ BeforeAll {
 }
 
 Describe 'Get-TeamViewerDevice' {
+    It 'Should reject a non-positive TeamViewer ID' {
+        { Get-TeamViewerDevice -ApiToken $testApiToken -TeamViewerId 0 } | Should -Throw
+    }
+
     It 'Should call the correct API endpoint to list devices' {
         Get-TeamViewerDevice -ApiToken $testApiToken
+
         Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
-            $ApiToken -eq $testApiToken -And `
-                $Uri -eq '//unit.test/devices' -And `
+            $ApiToken -eq $testApiToken -and `
+                $Uri -eq '//unit.test/devices' -and `
                 $Method -eq 'Get' }
     }
 
     It 'Should call the correct API endpoint for single device' {
         Get-TeamViewerDevice -ApiToken $testApiToken -Id 'd1234'
+
         Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
-            $ApiToken -eq $testApiToken -And `
-                $Uri -eq '//unit.test/devices/d1234' -And `
+            $ApiToken -eq $testApiToken -and `
+                $Uri -eq '//unit.test/devices/d1234' -and `
                 $Method -eq 'Get' }
     }
 
@@ -42,13 +47,15 @@ Describe 'Get-TeamViewerDevice' {
 
     It 'Should allow to filter by TeamViewer ID' {
         Get-TeamViewerDevice -ApiToken $testApiToken -TeamViewerId 123456789
+
         Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
-            $Body -And $Body['remotecontrol_id'] -eq 'r123456789' }
+            $Body -and $Body['remotecontrol_id'] -eq 'r123456789' }
     }
 
     It 'Should allow to filter by online state' {
         Get-TeamViewerDevice -ApiToken $testApiToken -FilterOnlineState 'Busy'
+
         Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
-            $Body -And $Body['online_state'] -eq 'busy' }
+            $Body -and $Body['online_state'] -eq 'busy' }
     }
 }

--- a/Tests/Public/Get-TeamViewerEventLog.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerEventLog.Tests.ps1
@@ -1,8 +1,7 @@
 BeforeAll {
     . "$PSScriptRoot\..\..\Cmdlets\Public\Get-TeamViewerEventLog.ps1"
 
-    @(Get-ChildItem -Path "$PSScriptRoot\..\..\Cmdlets\Private\*.ps1") | `
-        ForEach-Object { . $_.FullName }
+    @(Get-ChildItem -Path "$PSScriptRoot\..\..\Cmdlets\Private\*.ps1") | ForEach-Object { . $_.FullName }
 
     $testApiToken = [securestring]@{}
     $null = $testApiToken
@@ -10,25 +9,29 @@ BeforeAll {
 
     Mock Get-TeamViewerApiUri { '//unit.test' }
     Mock Invoke-TeamViewerRestMethod {
-        $mockArgs.Body = $Body;
+        $mockArgs.Body = $Body
         @{
             AuditEvents = @(
-                @{ Name = "Event1" },
-                @{ Name = "Event2" },
-                @{ Name = "Event3" },
-                @{ Name = "Event4" },
-                @{ Name = "Event5" }
+                @{ Name = 'Event1' },
+                @{ Name = 'Event2' },
+                @{ Name = 'Event3' },
+                @{ Name = 'Event4' },
+                @{ Name = 'Event5' }
             )
         } }
 }
 
 Describe 'Get-TeamViewerEventLog' {
 
+    It 'Should reject a negative limit' {
+        { Get-TeamViewerEventLog -ApiToken $testApiToken -Limit -1 } | Should -Throw
+    }
+
     It 'Should call the correct API endpoint to get audit-log events' {
         Get-TeamViewerEventLog -ApiToken $testApiToken
         Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
-            $ApiToken -eq $testApiToken -And `
-                $Uri -Eq '//unit.test/EventLogging' -And `
+            $ApiToken -eq $testApiToken -and `
+                $Uri -eq '//unit.test/EventLogging' -and `
                 $Method -eq 'Post' }
     }
 
@@ -43,31 +46,33 @@ Describe 'Get-TeamViewerEventLog' {
         Mock Invoke-TeamViewerRestMethod { @{
                 ContinuationToken = 'abc'
                 AuditEvents       = @(
-                    @{ Name = "Event1" },
-                    @{ Name = "Event2" },
-                    @{ Name = "Event3" },
-                    @{ Name = "Event4" },
-                    @{ Name = "Event5" }
+                    @{ Name = 'Event1' },
+                    @{ Name = 'Event2' },
+                    @{ Name = 'Event3' },
+                    @{ Name = 'Event4' },
+                    @{ Name = 'Event5' }
                 )
             } }
+
         Mock Invoke-TeamViewerRestMethod { @{
                 ContinuationToken = 'foo'
                 AuditEvents       = @(
-                    @{ Name = "Event6" },
-                    @{ Name = "Event7" }
+                    @{ Name = 'Event6' },
+                    @{ Name = 'Event7' }
                 )
             } } -ParameterFilter {
-            $Body -And `
+            $Body -and `
             ([System.Text.Encoding]::UTF8.GetString($Body) | ConvertFrom-Json).ContinuationToken -eq 'abc'
         }
+
         Mock Invoke-TeamViewerRestMethod { @{
                 ContinuationToken = $null
                 AuditEvents       = @(
-                    @{ Name = "Event8" },
-                    @{ Name = "Event9" }
+                    @{ Name = 'Event8' },
+                    @{ Name = 'Event9' }
                 )
             } } -ParameterFilter {
-            $Body -And `
+            $Body -and `
             ([System.Text.Encoding]::UTF8.GetString($Body) | ConvertFrom-Json).ContinuationToken -eq 'foo'
         }
 
@@ -79,6 +84,7 @@ Describe 'Get-TeamViewerEventLog' {
 
     It 'Should filter by event names' {
         Get-TeamViewerEventLog -ApiToken $testApiToken -EventNames 'UserDeleted', 'UserGroupUpdated'
+
         $mockArgs.Body | Should -Not -BeNullOrEmpty
         $body = [System.Text.Encoding]::UTF8.GetString($mockArgs.Body) | ConvertFrom-Json
         $body.EventNames | Should -HaveCount 2
@@ -88,6 +94,7 @@ Describe 'Get-TeamViewerEventLog' {
 
     It 'Should filter by event types' {
         Get-TeamViewerEventLog -ApiToken $testApiToken -EventTypes 'CustomModules', 'Session'
+
         $mockArgs.Body | Should -Not -BeNullOrEmpty
         $body = [System.Text.Encoding]::UTF8.GetString($mockArgs.Body) | ConvertFrom-Json
         $body.EventTypes | Should -HaveCount 2
@@ -101,6 +108,7 @@ Describe 'Get-TeamViewerEventLog' {
             -AccountEmails 'foo@unit.test', 'bar@unit.test' `
             -AffectedItem 'my item' `
             -RemoteControlSessionId '6a5e870b-03d2-4e96-ac21-1d45c40c471b'
+
         $mockArgs.Body | Should -Not -BeNullOrEmpty
         $body = [System.Text.Encoding]::UTF8.GetString($mockArgs.Body) | ConvertFrom-Json
         $body.AccountEmails | Should -HaveCount 2
@@ -120,6 +128,7 @@ Describe 'Get-TeamViewerEventLog' {
             function Get-TestStartEndDate {
                 $mockArgs.Body | Should -Not -BeNullOrEmpty
                 $bodyText = [System.Text.Encoding]::UTF8.GetString($mockArgs.Body)
+
                 if ('System.Text.Json.JsonSerializer' -as [type]) {
                     # ConvertFrom-Json does some automatic datetime conversion.
                     # We don't want that here, so we parse manually.
@@ -128,13 +137,16 @@ Describe 'Get-TeamViewerEventLog' {
                     $body.EndDate | Should -Not -BeNullOrEmpty
                     $startDate = [System.DateTime]::ParseExact($body.StartDate, 'yyyy-MM-ddTHH:mm:ssZ', [CultureInfo]::InvariantCulture)
                     $endDate = [System.DateTime]::ParseExact($body.EndDate, 'yyyy-MM-ddTHH:mm:ssZ', [CultureInfo]::InvariantCulture)
-                } else {
+                }
+                else {
                     # we can only do the above check in .NET core and above
                     $body = $bodyText | ConvertFrom-Json
                     $startDate = $body.StartDate
                     $endDate = $body.EndDate
                 }
+
                 $startDate | Should -BeLessThan $endDate
+
                 return @{
                     StartDate = $startDate
                     EndDate   = $endDate
@@ -145,12 +157,14 @@ Describe 'Get-TeamViewerEventLog' {
 
         It 'Should use relative dates by default' {
             Get-TeamViewerEventLog -ApiToken $testApiToken
+
             $dates = Get-TestStartEndDate
             $dates.Diff.TotalHours | Should -Be 1
         }
 
         It 'Should set start date months in the past' {
             Get-TeamViewerEventLog -ApiToken $testApiToken -Months 3
+
             $dates = Get-TestStartEndDate
             $dates.Diff.TotalDays | Should -BeLessOrEqual (3 * 31)
             $dates.Diff.TotalDays | Should -BeGreaterOrEqual (3 * 28)
@@ -158,27 +172,31 @@ Describe 'Get-TeamViewerEventLog' {
 
         It 'Should set start date days in the past' {
             Get-TeamViewerEventLog -ApiToken $testApiToken -Days 7
+
             $dates = Get-TestStartEndDate
             $dates.Diff.TotalDays | Should -Be 7
         }
 
         It 'Should set start date hours in the past' {
             Get-TeamViewerEventLog -ApiToken $testApiToken -Hours 12
+
             $dates = Get-TestStartEndDate
             $dates.Diff.TotalHours | Should -Be 12
         }
 
         It 'Should set start date minutes in the past' {
             Get-TeamViewerEventLog -ApiToken $testApiToken -Minutes 45
+
             $dates = Get-TestStartEndDate
             $dates.Diff.TotalMinutes | Should -Be 45
         }
 
         It 'Should set exact start-end dates' {
-            Get-TeamViewerEventLog -ApiToken $testApiToken -StartDate "1999-12-31" -EndDate "2021-11-09"
+            Get-TeamViewerEventLog -ApiToken $testApiToken -StartDate '1999-12-31' -EndDate '2021-11-09'
+
             $dates = Get-TestStartEndDate
-            $dates.StartDate | Should -Be ([datetime]"1999-12-31")
-            $dates.EndDate | Should -Be ([datetime]"2021-11-09")
+            $dates.StartDate | Should -Be ([datetime]'1999-12-31')
+            $dates.EndDate | Should -Be ([datetime]'2021-11-09')
         }
     }
 }

--- a/Tests/Public/Invoke-TeamViewerPackageDownload.Tests.ps1
+++ b/Tests/Public/Invoke-TeamViewerPackageDownload.Tests.ps1
@@ -1,6 +1,19 @@
 BeforeAll {
-    . "$PSScriptRoot\..\..\Cmdlets\Public\Invoke-TeamViewerPakcageDownload.ps1"
+    . "$PSScriptRoot\..\..\Cmdlets\Public\Invoke-TeamViewerPackageDownload.ps1"
 
-    @(Get-ChildItem -Path "$PSScriptRoot\..\..\Cmdlets\Private\*.ps1") | `
-        ForEach-Object { . $_.FullName }
+    @(Get-ChildItem -Path "$PSScriptRoot\..\..\Cmdlets\Private\*.ps1") | ForEach-Object { . $_.FullName }
+}
+
+Describe 'Invoke-TeamViewerPackageDownload' {
+    It 'Should reject unsupported TeamViewer versions' {
+        { Invoke-TeamViewerPackageDownload -PackageType Full -MajorVersion 13 -TargetDirectory (Get-Location).Path } | Should -Throw
+    }
+
+    It 'Should reject major versions for MSI packages' {
+        { Invoke-TeamViewerPackageDownload -PackageType MSI64 -MajorVersion 15 -TargetDirectory (Get-Location).Path } | Should -Throw
+    }
+
+    It 'Should reject a missing target directory' {
+        { Invoke-TeamViewerPackageDownload -PackageType Full -TargetDirectory (Join-Path (Get-Location).Path 'missing') } | Should -Throw
+    }
 }

--- a/Tests/Public/New-TeamViewerDevice.Tests.ps1
+++ b/Tests/Public/New-TeamViewerDevice.Tests.ps1
@@ -1,8 +1,7 @@
 BeforeAll {
     . "$PSScriptRoot\..\..\Cmdlets\Public\New-TeamViewerDevice.ps1"
 
-    @(Get-ChildItem -Path "$PSScriptRoot\..\..\Cmdlets\Private\*.ps1") | `
-        ForEach-Object { . $_.FullName }
+    @(Get-ChildItem -Path "$PSScriptRoot\..\..\Cmdlets\Private\*.ps1") | ForEach-Object { . $_.FullName }
 
     $testApiToken = [securestring]@{}
     $null = $testApiToken
@@ -21,22 +20,31 @@ BeforeAll {
     function ConvertTo-TestPassword {
         # We do this only for testing
         [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
+
         param()
-        Process { $_ | ConvertTo-SecureString -AsPlainText -Force }
+        process {
+            $_ | ConvertTo-SecureString -AsPlainText -Force
+        }
     }
 }
 
 Describe 'New-TeamViewerDevice' {
+    It 'Should reject a non-positive TeamViewer ID' {
+        { New-TeamViewerDevice -ApiToken $testApiToken -TeamViewerId 0 -Group 'g5678' } | Should -Throw
+    }
+
     It 'Should call the correct API endpoint' {
         New-TeamViewerDevice -ApiToken $testApiToken -TeamViewerId 1234 -Group 'g5678'
+
         Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
-            $ApiToken -eq $testApiToken -And `
-                $Uri -eq '//unit.test/devices' -And `
+            $ApiToken -eq $testApiToken -and `
+                $Uri -eq '//unit.test/devices' -and `
                 $Method -eq 'Post' }
     }
 
     It 'Should include the given input parameters in the request' {
         $testPassword = 'Test1234' | ConvertTo-TestPassword
+
         New-TeamViewerDevice `
             -ApiToken $testApiToken `
             -TeamViewerId 1234 `
@@ -44,6 +52,7 @@ Describe 'New-TeamViewerDevice' {
             -Name 'My Device' `
             -Description 'Some Device' `
             -Password $testPassword
+
         $mockArgs.Body | Should -Not -BeNullOrEmpty
         $body = [System.Text.Encoding]::UTF8.GetString($mockArgs.Body) | ConvertFrom-Json
         $body.remotecontrol_id | Should -Be 'r1234'
@@ -55,7 +64,9 @@ Describe 'New-TeamViewerDevice' {
 
     It 'Should accept Group objects' {
         $testGroupObj = @{ id = 'g5678' } | ConvertTo-TeamViewerGroup
+
         New-TeamViewerDevice -ApiToken $testApiToken -TeamViewerId 1234 -Group $testGroupObj
+
         $mockArgs.Body | Should -Not -BeNullOrEmpty
         $body = [System.Text.Encoding]::UTF8.GetString($mockArgs.Body) | ConvertFrom-Json
         $body.remotecontrol_id | Should -Be 'r1234'


### PR DESCRIPTION
Add (boundary) validation for public cmdlet parameters and regression coverage for invalid values.