### PR TITLE
Improve local error handling

### DIFF
--- a/Cmdlets/Public/Get-TeamViewerCustomModuleId.ps1
+++ b/Cmdlets/Public/Get-TeamViewerCustomModuleId.ps1
@@ -1,22 +1,31 @@
 function Get-TeamViewerCustomModuleId {
+    if (Test-TeamViewerInstallation) {
+        $TV_AssignmentFilePath = (Join-Path -Path (Get-TeamViewerInstallationDirectory) -ChildPath 'TeamViewer.json')
 
-    if (Test-TeamViewerinstallation) {
-        $fileName = 'TeamViewer.json'
-        $installationDirectory = Get-TeamViewerInstallationDirectory
-        $filePath = Join-Path -Path $installationDirectory -ChildPath $fileName
-        if (Test-Path -Path $filePath) {
-            $jsonContent = Get-Content -Path $FilePath -Raw
-            $jsonObject = ConvertFrom-Json $jsonContent
-            if ($jsonObject.id) {
-                return $jsonObject.id
+        if (Test-Path -Path $TV_AssignmentFilePath) {
+            try {
+                $TV_AssignmentJson = Get-Content -Path $TV_AssignmentFilePath -Raw -ErrorAction Stop
+                $jsonObject = ConvertFrom-Json $TV_AssignmentJson
+
+                if ($jsonObject.id) {
+                    return $jsonObject.id
+                }
+            }
+            catch {
+                Write-Verbose "Failed to read the custom module ID from '$TV_AssignmentFilePath': $($_.Exception.Message)"
+
+                return $null
             }
         }
         else {
-            Write-Error 'Custom module Id cannot be found. Check if customization is applied.'
+            Write-Verbose 'Custom module Id cannot be found. Check if customization is applied.'
+
+            return $null
         }
     }
     else {
-        Write-Error 'TeamViewer is not installed'
-    }
+        Write-Verbose 'TeamViewer is not installed!'
 
+        return $null
+    }
 }

--- a/Cmdlets/Public/Get-TeamViewerInstallationPackage.ps1
+++ b/Cmdlets/Public/Get-TeamViewerInstallationPackage.ps1
@@ -2,7 +2,14 @@ function Get-TeamViewerInstallationPackage {
     if (Test-TeamViewerInstallation) {
         $TV_InstallationDirectory = Get-TeamViewerInstallationDirectory
 
-        $Package = (Get-Item -Path (Join-Path -Path $TV_InstallationDirectory -ChildPath 'TeamViewer.exe')).VersionInfo.ProductName
+        try {
+            $Package = (Get-Item -Path (Join-Path -Path $TV_InstallationDirectory -ChildPath 'TeamViewer.exe')).VersionInfo.ProductName
+        }
+        catch {
+            Write-Verbose "Failed to read the TeamViewer file attribute information: $($_.Exception.Message)"
+
+            return $null
+        }
 
         switch -Wildcard ($Package) {
             '*Full*' {
@@ -17,6 +24,8 @@ function Get-TeamViewerInstallationPackage {
         }
     }
     else {
+        Write-Verbose 'TeamViewer is not installed!'
+
         return $null
     }
 }

--- a/Cmdlets/Public/Get-TeamViewerManagementId.ps1
+++ b/Cmdlets/Public/Get-TeamViewerManagementId.ps1
@@ -1,13 +1,30 @@
 function Get-TeamViewerManagementId {
     if (Test-TeamViewerInstallation) {
-        $regKeyPath = Join-Path (Get-TeamViewerRegKeyPath) 'DeviceManagementV2'
-        $regKey = if (Test-Path -LiteralPath $regKeyPath) { Get-Item -Path $regKeyPath }
-        if ($regKey) {
-            $unmanaged = [bool]($regKey.GetValue('Unmanaged'))
-            $managementId = $regKey.GetValue('ManagementId')
+        try {
+            $RegKey_Path = Join-Path -Path (Get-TeamViewerRegKeyPath) -ChildPath 'DeviceManagementV2'
+
+            $RegKey = if (Test-Path -LiteralPath $RegKey_Path) {
+                Get-Item -Path $RegKey_Path
+            }
+
+            if ($RegKey) {
+                $IsUnmanaged = [bool]($RegKey.GetValue('Unmanaged'))
+                $ManagementId = $RegKey.GetValue('ManagementId')
+            }
+
+            if (-not $IsUnmanaged -and $ManagementId) {
+                Write-Output ([guid]$ManagementId)
+            }
         }
-        if (!$unmanaged -And $managementId) {
-            Write-Output ([guid]$managementId)
+        catch {
+            Write-Verbose "Failed to read the TeamViewer management ID: $($_.Exception.Message)"
+
+            return $null
         }
+    }
+    else {
+        Write-Verbose 'TeamViewer is not installed!'
+
+        return $null
     }
 }

--- a/Cmdlets/Public/Invoke-TeamViewerPackageDownload.ps1
+++ b/Cmdlets/Public/Invoke-TeamViewerPackageDownload.ps1
@@ -1,23 +1,23 @@
 function Invoke-TeamViewerPackageDownload {
-    Param(
-        [Parameter()]
+    param(
+        [Parameter(Mandatory = $true)]
         [ValidateSet('Full', 'Host', 'MSI32', 'MSI64', 'Portable', 'QuickJoin', 'QuickSupport', 'Full64Bit')]
         [string]
         $PackageType,
 
         [Parameter()]
         [ValidateScript( {
-                if($PackageType -eq 'MSI32' -or 'MSI64' ){
+                if ($PackageType -eq 'MSI32' -or $PackageType -eq 'MSI64' ) {
                     $PSCmdlet.ThrowTerminatingError(
-                        ("MajorVersion parameter is not supported for MSI packages" | `
-                                ConvertTo-ErrorRecord -ErrorCategory InvalidArgument))
+                        ('MajorVersion parameter is not supported for MSI packages' | ConvertTo-ErrorRecord -ErrorCategory InvalidArgument))
                 }
+
                 if ($_ -lt 14) {
                     $PSCmdlet.ThrowTerminatingError(
-                        ("Unsupported TeamViewer version $_" | `
-                                ConvertTo-ErrorRecord -ErrorCategory InvalidArgument))
+                        ("Unsupported TeamViewer version $_" | ConvertTo-ErrorRecord -ErrorCategory InvalidArgument))
                 }
-                $true
+
+                return $true
             } )]
         [int]
         $MajorVersion,
@@ -31,40 +31,66 @@ function Invoke-TeamViewerPackageDownload {
         $Force
     )
 
-    if (-not $PackageType) {
-        $Package = $host.ui.PromptForChoice('Select Package Type', 'Choose a package type:', `
-            @('Full', 'Host', 'MSI32', 'MSI64', 'Portable', 'QuickJoin', 'QuickSupport', 'Full64Bit'), 0)
-        $PackageType = @('Full', 'Host', 'MSI32', 'MSI64', 'Portable', 'QuickJoin', 'QuickSupport', 'Full64Bit')[$Package]
+    begin {
+        $Filename = switch ($PackageType) {
+            'Full' {
+                'TeamViewer_Setup.exe'
+            }
+            'MSI32' {
+                'TeamViewer_MSI32.zip'
+            }
+            'MSI64' {
+                'TeamViewer_MSI64.zip'
+            }
+            'Host' {
+                'TeamViewer_Host_Setup.exe'
+            }
+            'Portable' {
+                'TeamViewerPortable.zip'
+            }
+            'QuickJoin' {
+                'TeamViewerQJ.exe'
+            }
+            'QuickSupport' {
+                'TeamViewerQS.exe'
+            }
+            'Full64Bit' {
+                'TeamViewer_Setup_x64.exe'
+            }
+        }
+
+        $VersionEndpoint = ''
+
+        if ($MajorVersion) {
+            $VersionEndpoint = "/version_$($MajorVersion)x"
+        }
+
+        if ($PackageType -eq 'MSI32' -or $PackageType -eq 'MSI64') {
+            $VersionEndpoint = '/version_15x'
+        }
+
+        $Download_Url = "https://dl.teamviewer.com/download$VersionEndpoint/$Filename"
+        $Target_FilePath = Join-Path -Path $TargetDirectory -ChildPath $Filename
     }
 
-    $additionalPath = ''
-    $filename = switch ($PackageType) {
-        'Full' { 'TeamViewer_Setup.exe' }
-        'MSI32' { 'TeamViewer_MSI32.zip' }
-        'MSI64' { 'TeamViewer_MSI64.zip' }
-        'Host' { 'TeamViewer_Host_Setup.exe' }
-        'Portable' { 'TeamViewerPortable.zip' }
-        'QuickJoin' { 'TeamViewerQJ.exe' }
-        'QuickSupport' { 'TeamViewerQS.exe' }
-        'Full64Bit' { 'TeamViewer_Setup_x64.exe' }
-    }
-    if ($MajorVersion) {
-        $additionalPath = "/version_$($MajorVersion)x"
-    }
-    if(($PackageType -eq 'MSI32' -or 'MSI64' )){
-        $additionalPath = '/version_15x'
-    }
+    process {
+        if ((Test-Path -Path $Target_FilePath -PathType Leaf) -and (-not $Force)) {
+            Write-Verbose "File '$Target_FilePath' already exists. Use -Force parameter to overwrite."
 
-    $downloadUrl = "https://dl.teamviewer.com/download$additionalPath/$filename"
-    $targetFile = Join-Path $TargetDirectory $filename
+            return $null
+        }
 
-    if ((Test-Path $targetFile) -And -Not $Force -And `
-            -Not $PSCmdlet.ShouldContinue("File $targetFile already exists. Override?", "Override existing file?")) {
-        return
+        Write-Verbose "Downloading $Download_Url to $Target_FilePath..."
+
+        try {
+            Invoke-WebRequest -Uri $Download_Url -OutFile $Target_FilePath -UseBasicParsing -ErrorAction Stop
+
+            Write-Output $Target_FilePath
+        }
+        catch {
+            Write-Verbose "Failed to download TeamViewer package to '$Target_FilePath': $($_.Exception.Message)"
+
+            Write-Output $null
+        }
     }
-
-    Write-Verbose "Downloading $downloadUrl to $targetFile"
-    $client = New-Object System.Net.WebClient
-    $client.DownloadFile($downloadUrl, $targetFile)
-    Write-Output $targetFile
 }

--- a/Tests/Public/Get-TeamViewerCustomModuleId.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerCustomModuleId.Tests.ps1
@@ -2,8 +2,7 @@ BeforeAll {
     . "$PSScriptRoot\..\..\Cmdlets\Public\Get-TeamViewerCustomModuleId.ps1"
     . "$PSScriptRoot\..\..\Cmdlets\Public\Test-TeamViewerInstallation.ps1"
     . "$PSScriptRoot\..\..\Cmdlets\Public\Get-TeamViewerInstallationDirectory.ps1"
-    @(Get-ChildItem -Path "$PSScriptRoot\..\..\Cmdlets\Private\*.ps1") | `
-        ForEach-Object { . $_.FullName }
+    @(Get-ChildItem -Path "$PSScriptRoot\..\..\Cmdlets\Private\*.ps1") | ForEach-Object { . $_.FullName }
 }
 
 Describe 'Get-TeamViewerCustomModuleId' {
@@ -12,11 +11,13 @@ Describe 'Get-TeamViewerCustomModuleId' {
             Mock Test-TeamViewerInstallation { $true }
             Mock Test-Path { $true }
             Mock Get-Content { '{"id": "customModuleId"}' }
-            Mock Get-TeamViewerInstallationDirectory {return 'C:\'}
+            Mock Get-TeamViewerInstallationDirectory { return 'C:\' }
+
             $installationDirectory = Get-TeamViewerInstallationDirectory
-            $fileName ='TeamViewer.Json'
+            $fileName = 'TeamViewer.Json'
             $filePath = Join-Path -Path $installationDirectory -ChildPath $fileName
-            Mock -CommandName Join-Path -MockWith {$filePath}
+
+            Mock -CommandName Join-Path -MockWith { $filePath }
         }
 
         It 'Should return the custom module ID' {
@@ -30,16 +31,35 @@ Describe 'Get-TeamViewerCustomModuleId' {
     Context 'When TeamViewer is not installed' {
         BeforeAll {
             Mock Test-TeamViewerInstallation { $false }
-            Mock Write-Error {}
+            Mock Write-Verbose { }
         }
 
-        It 'Should write an error message' {
-            Mock Write-Error -ParameterFilter { $_ -eq 'TeamViewer is not installed' }
-            Get-TeamViewerCustomModuleId
-            Should -Invoke Write-Error -Scope It -Times 1
+        It 'Should write a verbose message' {
+            $result = Get-TeamViewerCustomModuleId
+
+            $result | Should -BeNullOrEmpty
+            Should -Invoke Write-Verbose -Scope It -Times 1 -ParameterFilter {
+                $Message -eq 'TeamViewer is not installed!'
+            }
         }
     }
 
+    Context 'When the customization file is invalid' {
+        BeforeAll {
+            Mock Test-TeamViewerInstallation { $true }
+            Mock Test-Path { $true }
+            Mock Get-TeamViewerInstallationDirectory { 'C:\' }
+            Mock Get-Content { throw 'invalid JSON' }
+            Mock Write-Verbose { }
+        }
+
+        It 'Should write a verbose failure message' {
+            $result = Get-TeamViewerCustomModuleId
+
+            $result | Should -BeNullOrEmpty
+            Should -Invoke Write-Verbose -Scope It -Times 1 -ParameterFilter {
+                $Message -like "Failed to read the custom module ID from*invalid JSON"
+            }
+        }
+    }
 }
-
-

--- a/Tests/Public/Get-TeamViewerInstallationPackage.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerInstallationPackage.Tests.ps1
@@ -9,6 +9,7 @@ Describe 'Get-TeamViewerInstallationPackage' {
     BeforeAll {
         Mock Test-TeamViewerInstallation { $true }
         Mock Get-TeamViewerInstallationDirectory { 'testPath' }
+
         $script:TV_InstallationDirectory = 'testPath'
 
         $script:testVersionInfo = [PSCustomObject]@{
@@ -16,10 +17,7 @@ Describe 'Get-TeamViewerInstallationPackage' {
         }
 
         $script:testItem = [PSCustomObject]@{}
-        $script:testItem | Add-Member `
-            -MemberType NoteProperty `
-            -Name VersionInfo `
-            -Value $script:testVersionInfo
+        $script:testItem | Add-Member -MemberType NoteProperty -Name VersionInfo -Value $script:testVersionInfo
 
         Mock Get-Item -ParameterFilter {
             $Path -eq (Join-Path -Path 'testPath' -ChildPath 'TeamViewer.exe')
@@ -60,5 +58,19 @@ Describe 'Get-TeamViewerInstallationPackage' {
         Get-TeamViewerInstallationPackage | Should -BeNullOrEmpty
 
         Should -Invoke Get-Item -Scope It -Times 0
+    }
+
+    It 'Should write a verbose message when installation metadata cannot be read' {
+        Mock Get-Item -ParameterFilter {
+            $Path -eq (Join-Path -Path 'testPath' -ChildPath 'TeamViewer.exe')
+        } { throw 'file not found' }
+        Mock Write-Verbose { }
+
+        $result = Get-TeamViewerInstallationPackage
+
+        $result | Should -BeNullOrEmpty
+        Should -Invoke Write-Verbose -Scope It -Times 1 -ParameterFilter {
+            $Message -like 'Failed to read the TeamViewer file attribute information:*'
+        }
     }
 }

--- a/Tests/Public/Get-TeamViewerManagementId.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerManagementId.Tests.ps1
@@ -2,8 +2,8 @@ BeforeAll {
     . "$PSScriptRoot\..\..\Cmdlets\Public\Get-TeamViewerManagementId.ps1"
 
     . "$PSScriptRoot\..\..\Cmdlets\Public\Test-TeamViewerInstallation.ps1"
-    @(Get-ChildItem -Path "$PSScriptRoot\..\..\Cmdlets\Private\*.ps1") | `
-        ForEach-Object { . $_.FullName }
+    @(Get-ChildItem -Path "$PSScriptRoot\..\..\Cmdlets\Private\*.ps1") | ForEach-Object { . $_.FullName }
+
     $testManagementId = New-Guid
     $null = $testManagementId
 }
@@ -12,6 +12,7 @@ Describe 'Get-TeamViewerManagementId' {
     BeforeAll {
         function Get-TestItemValue([object]$obj) {
         }
+
         Mock Get-TestItemValue `
             -ParameterFilter { $obj -eq 'Unmanaged' } { }
         Mock Get-TestItemValue `
@@ -29,6 +30,7 @@ Describe 'Get-TeamViewerManagementId' {
 
     It 'Should return the Management ID from the Windows Registry' {
         Get-TeamViewerManagementId | Should -Be $testManagementId
+
         Should -Invoke Test-TeamViewerInstallation -Scope It -Times 1
         Should -Invoke Get-TeamViewerRegKeyPath -Scope It -Times 1
         Should -Invoke Test-Path -Scope It -Times 1 -ParameterFilter {
@@ -47,21 +49,37 @@ Describe 'Get-TeamViewerManagementId' {
 
     It 'Should return nothing when TeamViewer is not installed' {
         Mock Test-TeamViewerInstallation { $false }
+
         Get-TeamViewerManagementId | Should -BeNullOrEmpty
     }
 
     It 'Should return nothing when registry path does not exist' {
         Mock Test-Path { $false }
+
         Get-TeamViewerManagementId | Should -BeNullOrEmpty
     }
 
     It 'Should return nothing when registry item does not exist' {
         Mock Get-Item { }
+
         Get-TeamViewerManagementId | Should -BeNullOrEmpty
     }
 
     It 'Should return nothing when the device is marked as unmanaged' {
         Mock Get-TestItemValue -ParameterFilter { $obj -eq 'Unmanaged' } { 1 }
+
         Get-TeamViewerManagementId | Should -BeNullOrEmpty
+    }
+
+    It 'Should write an error when the registry contains an invalid Management ID' {
+        Mock Get-TestItemValue -ParameterFilter { $obj -eq 'ManagementId' } { 'invalid' }
+        Mock Write-Verbose { }
+
+        $result = Get-TeamViewerManagementId
+
+        $result | Should -BeNullOrEmpty
+        Should -Invoke Write-Verbose -Scope It -Times 1 -ParameterFilter {
+            $Message -like 'Failed to read the TeamViewer management ID:*'
+        }
     }
 }

--- a/Tests/Public/Invoke-TeamViewerPackageDownload.Tests.ps1
+++ b/Tests/Public/Invoke-TeamViewerPackageDownload.Tests.ps1
@@ -1,6 +1,47 @@
 BeforeAll {
-    . "$PSScriptRoot\..\..\Cmdlets\Public\Invoke-TeamViewerPakcageDownload.ps1"
+    . "$PSScriptRoot\..\..\Cmdlets\Public\Invoke-TeamViewerPackageDownload.ps1"
 
-    @(Get-ChildItem -Path "$PSScriptRoot\..\..\Cmdlets\Private\*.ps1") | `
-        ForEach-Object { . $_.FullName }
+    @(Get-ChildItem -Path "$PSScriptRoot\..\..\Cmdlets\Private\*.ps1") | ForEach-Object { . $_.FullName }
+}
+
+Describe 'Invoke-TeamViewerPackageDownload' {
+    It 'Should download the selected package' {
+        Mock Test-Path { $false }
+        Mock Invoke-WebRequest { }
+
+        $result = Invoke-TeamViewerPackageDownload -PackageType Full -TargetDirectory 'testPath'
+
+        $result | Should -Be 'testPath\TeamViewer_Setup.exe'
+        Should -Invoke Invoke-WebRequest -Times 1 -Scope It -ParameterFilter {
+            $Uri -eq 'https://dl.teamviewer.com/download/TeamViewer_Setup.exe' -and
+            $OutFile -eq 'testPath\TeamViewer_Setup.exe' -and
+            $UseBasicParsing -and
+            $ErrorAction -eq 'Stop'
+        }
+    }
+
+    It 'Should report download failures' {
+        Mock Test-Path { $false }
+        Mock Invoke-WebRequest { throw 'download failed' }
+        Mock Write-Verbose { }
+
+        $result = Invoke-TeamViewerPackageDownload -PackageType Full -TargetDirectory 'testPath'
+
+        $result | Should -BeNullOrEmpty
+
+        Should -Invoke Write-Verbose -Times 1 -Scope It -ParameterFilter {
+            $Message -like "Failed to download TeamViewer package to 'testPath\TeamViewer_Setup.exe':*"
+        }
+    }
+
+    It 'Should skip an existing package without Force' {
+        Mock Test-Path { $true }
+        Mock Invoke-WebRequest { }
+
+        $result = Invoke-TeamViewerPackageDownload -PackageType Full -TargetDirectory 'testPath'
+
+        $result | Should -BeNullOrEmpty
+
+        Should -Invoke Invoke-WebRequest -Times 0 -Scope It
+    }
 }

--- a/Tests/Public/Invoke-TeamViewerPackageDownload.Tests.ps1
+++ b/Tests/Public/Invoke-TeamViewerPackageDownload.Tests.ps1
@@ -2,43 +2,46 @@ BeforeAll {
     . "$PSScriptRoot\..\..\Cmdlets\Public\Invoke-TeamViewerPackageDownload.ps1"
 
     @(Get-ChildItem -Path "$PSScriptRoot\..\..\Cmdlets\Private\*.ps1") | ForEach-Object { . $_.FullName }
+
+    $testTargetDirectory = Join-Path -Path $TestDrive -ChildPath 'downloads'
+    New-Item -Path $testTargetDirectory -ItemType Directory | Out-Null
 }
 
 Describe 'Invoke-TeamViewerPackageDownload' {
     It 'Should download the selected package' {
-        Mock Test-Path { $false }
         Mock Invoke-WebRequest { }
 
-        $result = Invoke-TeamViewerPackageDownload -PackageType Full -TargetDirectory 'testPath'
+        $result = Invoke-TeamViewerPackageDownload -PackageType Full -TargetDirectory $testTargetDirectory
 
-        $result | Should -Be 'testPath\TeamViewer_Setup.exe'
+        $result | Should -Be (Join-Path $testTargetDirectory 'TeamViewer_Setup.exe')
+
         Should -Invoke Invoke-WebRequest -Times 1 -Scope It -ParameterFilter {
             $Uri -eq 'https://dl.teamviewer.com/download/TeamViewer_Setup.exe' -and
-            $OutFile -eq 'testPath\TeamViewer_Setup.exe' -and
+            $OutFile -eq (Join-Path $testTargetDirectory 'TeamViewer_Setup.exe') -and
             $UseBasicParsing -and
             $ErrorAction -eq 'Stop'
         }
     }
 
     It 'Should report download failures' {
-        Mock Test-Path { $false }
         Mock Invoke-WebRequest { throw 'download failed' }
         Mock Write-Verbose { }
 
-        $result = Invoke-TeamViewerPackageDownload -PackageType Full -TargetDirectory 'testPath'
+        $result = Invoke-TeamViewerPackageDownload -PackageType Full -TargetDirectory $testTargetDirectory
 
         $result | Should -BeNullOrEmpty
 
         Should -Invoke Write-Verbose -Times 1 -Scope It -ParameterFilter {
-            $Message -like "Failed to download TeamViewer package to 'testPath\TeamViewer_Setup.exe':*"
+            $Message -like "Failed to download TeamViewer package to '$testTargetDirectory\TeamViewer_Setup.exe':*"
         }
     }
 
     It 'Should skip an existing package without Force' {
-        Mock Test-Path { $true }
+        New-Item -Path (Join-Path $testTargetDirectory 'TeamViewer_Setup.exe') -ItemType File | Out-Null
+
         Mock Invoke-WebRequest { }
 
-        $result = Invoke-TeamViewerPackageDownload -PackageType Full -TargetDirectory 'testPath'
+        $result = Invoke-TeamViewerPackageDownload -PackageType Full -TargetDirectory $testTargetDirectory
 
         $result | Should -BeNullOrEmpty
 


### PR DESCRIPTION
Improve local failure handling across installation metadata, custom module ID, management ID, and package download operations.

Changes include:
- Add focused try/catch handling with verbose diagnostics and null results for local read and parsing failures.
- Replace WebClient downloads with PowerShell 5+-compatible Invoke-WebRequest.
- Add -ErrorAction Stop to ensure download failures are caught.
- Expand tests for successful downloads, failures, existing-file skips, invalid JSON, missing metadata, and invalid management IDs.

Change #130 is needed to get tests running.