### PR TITLE
Rename DeviceCustomField cmdlets to DeviceCustomFieldConfiguration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@
 
 ### Added
 
-- Adds `Get-TeamViewerDeviceCustomField` to retrieve all device custom fields.
-- Adds `New-TeamViewerDeviceCustomField` to create a new device custom field.
-- Adds `Set-TeamViewerDeviceCustomField` to modify one specific device custom field.
-- Adds `Remove-TeamViewerDeviceCustomField` to delete one specific device custom field.
+- Adds `Get-TeamViewerDeviceCustomFieldConfiguration` to retrieve all device custom fields.
+- Adds `New-TeamViewerDeviceCustomFieldConfiguration` to create a new device custom field.
+- Adds `Set-TeamViewerDeviceCustomFieldConfiguration` to modify one specific device custom field.
+- Adds `Remove-TeamViewerDeviceCustomFieldConfiguration` to delete one specific device custom field.
 
 ### Changed
 

--- a/Cmdlets/Private/ConvertTo-TeamViewerDeviceCustomFieldConfiguration.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerDeviceCustomFieldConfiguration.ps1
@@ -1,4 +1,4 @@
-function ConvertTo-TeamViewerDeviceCustomField {
+function ConvertTo-TeamViewerDeviceCustomFieldConfiguration {
     param(
         [Parameter(ValueFromPipeline)]
         [PSObject]
@@ -16,7 +16,7 @@ function ConvertTo-TeamViewerDeviceCustomField {
         }
 
         $Result = New-Object -TypeName PSObject -Property $Properties
-        $Result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.DeviceCustomField')
+        $Result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.DeviceCustomFieldConfiguration')
 
         $Result | Add-Member -MemberType ScriptMethod -Name 'ToString' -Force -Value {
             '{0} ({1})' -f $this.FieldKey, $this.Id

--- a/Cmdlets/Public/Get-TeamViewerDeviceCustomFieldConfiguration.ps1
+++ b/Cmdlets/Public/Get-TeamViewerDeviceCustomFieldConfiguration.ps1
@@ -1,7 +1,7 @@
-function Get-TeamViewerDeviceCustomField {
+function Get-TeamViewerDeviceCustomFieldConfiguration {
     [CmdletBinding()]
 
-    [OutputType('TeamViewerPS.DeviceCustomField')]
+    [OutputType('TeamViewerPS.DeviceCustomFieldConfiguration')]
 
     param(
         [Parameter(Mandatory = $true)]
@@ -21,6 +21,6 @@ function Get-TeamViewerDeviceCustomField {
             -WriteErrorTo $PSCmdlet `
             -ErrorAction Stop
 
-        Write-Output ($Response.resources | ConvertTo-TeamViewerDeviceCustomField)
+        Write-Output ($Response.resources | ConvertTo-TeamViewerDeviceCustomFieldConfiguration)
     }
 }

--- a/Cmdlets/Public/New-TeamViewerDeviceCustomFieldConfiguration.ps1
+++ b/Cmdlets/Public/New-TeamViewerDeviceCustomFieldConfiguration.ps1
@@ -1,17 +1,12 @@
-function Set-TeamViewerDeviceCustomField {
+function New-TeamViewerDeviceCustomFieldConfiguration {
     [CmdletBinding(SupportsShouldProcess = $true)]
 
-    [OutputType('TeamViewerPS.DeviceCustomField')]
+    [OutputType('TeamViewerPS.DeviceCustomFieldConfiguration')]
 
     param(
         [Parameter(Mandatory = $true)]
         [securestring]
         $ApiToken,
-
-        [Parameter(Mandatory = $true)]
-        [Alias('FieldKeyId')]
-        [guid]
-        $Id,
 
         [Parameter(Mandatory = $true)]
         [string]
@@ -32,21 +27,21 @@ function Set-TeamViewerDeviceCustomField {
             $Body['description'] = $Description
         }
 
-        $ResourceUri = "$(Get-TeamViewerApiUri)/device-custom-fields/$Id"
+        $ResourceUri = "$(Get-TeamViewerApiUri)/device-custom-fields"
     }
 
     process {
-        if ($PSCmdlet.ShouldProcess($Id, 'Update device custom field')) {
+        if ($PSCmdlet.ShouldProcess($FieldKey, 'Create device custom field')) {
             $Response = Invoke-TeamViewerRestMethod `
                 -ApiToken $ApiToken `
                 -Uri $ResourceUri `
-                -Method Put `
+                -Method Post `
                 -ContentType 'application/json; charset=utf-8' `
                 -Body ([System.Text.Encoding]::UTF8.GetBytes(($Body | ConvertTo-Json))) `
                 -WriteErrorTo $PSCmdlet `
                 -ErrorAction Stop
 
-            Write-Output ($Response | ConvertTo-TeamViewerDeviceCustomField)
+            Write-Output ($Response | ConvertTo-TeamViewerDeviceCustomFieldConfiguration)
         }
     }
 }

--- a/Cmdlets/Public/Remove-TeamViewerDeviceCustomFieldConfiguration.ps1
+++ b/Cmdlets/Public/Remove-TeamViewerDeviceCustomFieldConfiguration.ps1
@@ -1,4 +1,4 @@
-function Remove-TeamViewerDeviceCustomField {
+function Remove-TeamViewerDeviceCustomFieldConfiguration {
     [CmdletBinding(SupportsShouldProcess = $true)]
 
     [OutputType([void])]

--- a/Cmdlets/Public/Set-TeamViewerDeviceCustomFieldConfiguration.ps1
+++ b/Cmdlets/Public/Set-TeamViewerDeviceCustomFieldConfiguration.ps1
@@ -1,12 +1,17 @@
-function New-TeamViewerDeviceCustomField {
+function Set-TeamViewerDeviceCustomFieldConfiguration {
     [CmdletBinding(SupportsShouldProcess = $true)]
 
-    [OutputType('TeamViewerPS.DeviceCustomField')]
+    [OutputType('TeamViewerPS.DeviceCustomFieldConfiguration')]
 
     param(
         [Parameter(Mandatory = $true)]
         [securestring]
         $ApiToken,
+
+        [Parameter(Mandatory = $true)]
+        [Alias('FieldKeyId')]
+        [guid]
+        $Id,
 
         [Parameter(Mandatory = $true)]
         [string]
@@ -27,21 +32,21 @@ function New-TeamViewerDeviceCustomField {
             $Body['description'] = $Description
         }
 
-        $ResourceUri = "$(Get-TeamViewerApiUri)/device-custom-fields"
+        $ResourceUri = "$(Get-TeamViewerApiUri)/device-custom-fields/$Id"
     }
 
     process {
-        if ($PSCmdlet.ShouldProcess($FieldKey, 'Create device custom field')) {
+        if ($PSCmdlet.ShouldProcess($Id, 'Update device custom field')) {
             $Response = Invoke-TeamViewerRestMethod `
                 -ApiToken $ApiToken `
                 -Uri $ResourceUri `
-                -Method Post `
+                -Method Put `
                 -ContentType 'application/json; charset=utf-8' `
                 -Body ([System.Text.Encoding]::UTF8.GetBytes(($Body | ConvertTo-Json))) `
                 -WriteErrorTo $PSCmdlet `
                 -ErrorAction Stop
 
-            Write-Output ($Response | ConvertTo-TeamViewerDeviceCustomField)
+            Write-Output ($Response | ConvertTo-TeamViewerDeviceCustomFieldConfiguration)
         }
     }
 }

--- a/Docs/Help/Get-TeamViewerDeviceCustomFieldConfiguration.md
+++ b/Docs/Help/Get-TeamViewerDeviceCustomFieldConfiguration.md
@@ -1,11 +1,11 @@
 ---
 external help file: TeamViewerPS-help.xml
 Module Name: TeamViewerPS
-online version: https://github.com/teamviewer/TeamViewerPS/blob/main/Docs/Help/Get-TeamViewerDeviceCustomField.md
+online version: https://github.com/teamviewer/TeamViewerPS/blob/main/Docs/Help/Get-TeamViewerDeviceCustomFieldConfiguration.md
 schema: 2.0.0
 ---
 
-# Get-TeamViewerDeviceCustomField
+# Get-TeamViewerDeviceCustomFieldConfiguration
 
 ## SYNOPSIS
 
@@ -14,7 +14,7 @@ Lists device custom field definitions for the company.
 ## SYNTAX
 
 ```powershell
-Get-TeamViewerDeviceCustomField [-ApiToken] <SecureString> [<CommonParameters>]
+Get-TeamViewerDeviceCustomFieldConfiguration [-ApiToken] <SecureString> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -37,13 +37,13 @@ Required: True
 ### Example 1
 
 ```powershell
-Get-TeamViewerDeviceCustomField -ApiToken $apiToken
+Get-TeamViewerDeviceCustomFieldConfiguration -ApiToken $apiToken
 ```
 
 Lists all device custom fields in the company.
 
 ## OUTPUTS
 
-### TeamViewerPS.DeviceCustomField
+### TeamViewerPS.DeviceCustomFieldConfiguration
 
 Returns device custom field definition objects.

--- a/Docs/Help/New-TeamViewerDeviceCustomFieldConfiguration.md
+++ b/Docs/Help/New-TeamViewerDeviceCustomFieldConfiguration.md
@@ -1,11 +1,11 @@
 ---
 external help file: TeamViewerPS-help.xml
 Module Name: TeamViewerPS
-online version: https://github.com/teamviewer/TeamViewerPS/blob/main/Docs/Help/New-TeamViewerDeviceCustomField.md
+online version: https://github.com/teamviewer/TeamViewerPS/blob/main/Docs/Help/New-TeamViewerDeviceCustomFieldConfiguration.md
 schema: 2.0.0
 ---
 
-# New-TeamViewerDeviceCustomField
+# New-TeamViewerDeviceCustomFieldConfiguration
 
 ## SYNOPSIS
 
@@ -14,7 +14,7 @@ Creates a device custom field definition for the company.
 ## SYNTAX
 
 ```powershell
-New-TeamViewerDeviceCustomField [-ApiToken] <SecureString> [-FieldKey] <String> [[-Description] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+New-TeamViewerDeviceCustomFieldConfiguration [-ApiToken] <SecureString> [-FieldKey] <String> [[-Description] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -40,13 +40,13 @@ An optional description of the custom field.
 ### Example 1
 
 ```powershell
-New-TeamViewerDeviceCustomField -ApiToken $apiToken -FieldKey 'AssetTag' -Description 'Device asset tag'
+New-TeamViewerDeviceCustomFieldConfiguration -ApiToken $apiToken -FieldKey 'AssetTag' -Description 'Device asset tag'
 ```
 
 Creates an `AssetTag` device custom field with a description.
 
 ## OUTPUTS
 
-### TeamViewerPS.DeviceCustomField
+### TeamViewerPS.DeviceCustomFieldConfiguration
 
 Returns the created device custom field definition.

--- a/Docs/Help/Remove-TeamViewerDeviceCustomFieldConfiguration.md
+++ b/Docs/Help/Remove-TeamViewerDeviceCustomFieldConfiguration.md
@@ -1,11 +1,11 @@
 ---
 external help file: TeamViewerPS-help.xml
 Module Name: TeamViewerPS
-online version: https://github.com/teamviewer/TeamViewerPS/blob/main/Docs/Help/Remove-TeamViewerDeviceCustomField.md
+online version: https://github.com/teamviewer/TeamViewerPS/blob/main/Docs/Help/Remove-TeamViewerDeviceCustomFieldConfiguration.md
 schema: 2.0.0
 ---
 
-# Remove-TeamViewerDeviceCustomField
+# Remove-TeamViewerDeviceCustomFieldConfiguration
 
 ## SYNOPSIS
 
@@ -14,7 +14,7 @@ Deletes a device custom field definition.
 ## SYNTAX
 
 ```powershell
-Remove-TeamViewerDeviceCustomField [-ApiToken] <SecureString> [-Id] <Guid> [-WhatIf] [-Confirm] [<CommonParameters>]
+Remove-TeamViewerDeviceCustomFieldConfiguration [-ApiToken] <SecureString> [-Id] <Guid> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -36,7 +36,7 @@ The unique identifier of the custom field definition. Alias: FieldKeyId.
 ### Example 1
 
 ```powershell
-Remove-TeamViewerDeviceCustomField -ApiToken $apiToken -Id $fieldId
+Remove-TeamViewerDeviceCustomFieldConfiguration -ApiToken $apiToken -Id $fieldId
 ```
 
 Deletes the device custom field identified by `$fieldId` and its stored device values.

--- a/Docs/Help/Set-TeamViewerDeviceCustomFieldConfiguration.md
+++ b/Docs/Help/Set-TeamViewerDeviceCustomFieldConfiguration.md
@@ -1,11 +1,11 @@
 ---
 external help file: TeamViewerPS-help.xml
 Module Name: TeamViewerPS
-online version: https://github.com/teamviewer/TeamViewerPS/blob/main/Docs/Help/Set-TeamViewerDeviceCustomField.md
+online version: https://github.com/teamviewer/TeamViewerPS/blob/main/Docs/Help/Set-TeamViewerDeviceCustomFieldConfiguration.md
 schema: 2.0.0
 ---
 
-# Set-TeamViewerDeviceCustomField
+# Set-TeamViewerDeviceCustomFieldConfiguration
 
 ## SYNOPSIS
 
@@ -14,7 +14,7 @@ Updates a device custom field definition.
 ## SYNTAX
 
 ```powershell
-Set-TeamViewerDeviceCustomField [-ApiToken] <SecureString> [-Id] <Guid> [-FieldKey] <String> [[-Description] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Set-TeamViewerDeviceCustomFieldConfiguration [-ApiToken] <SecureString> [-Id] <Guid> [-FieldKey] <String> [[-Description] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -44,7 +44,7 @@ An optional description of the custom field.
 ### Example 1
 
 ```powershell
-Set-TeamViewerDeviceCustomField -ApiToken $apiToken -Id $fieldId -FieldKey 'AssetTag'
+Set-TeamViewerDeviceCustomFieldConfiguration -ApiToken $apiToken -Id $fieldId -FieldKey 'AssetTag'
 ```
 
 Updates the custom field identified by `$fieldId` and sets its key to `AssetTag`.

--- a/Docs/TeamViewerPS.md
+++ b/Docs/TeamViewerPS.md
@@ -151,7 +151,7 @@ Manage the managed groups and managed devices of an account / company / tenant v
 
 [`Get-TeamViewerCompanyManagedDevice`](Help/Get-TeamViewerCompanyManagedDevice.md)
 
-[`Get-TeamViewerDeviceCustomField`](Help/Get-TeamViewerDeviceCustomField.md)
+[`Get-TeamViewerDeviceCustomFieldConfiguration`](Help/Get-TeamViewerDeviceCustomFieldConfiguration.md)
 
 [`Get-TeamViewerManagedDevice`](Help/Get-TeamViewerManagedDevice.md)
 
@@ -163,11 +163,11 @@ Manage the managed groups and managed devices of an account / company / tenant v
 
 [`Move-TeamViewerManagedDevice`](Help/Move-TeamViewerManagedDevice.md)
 
-[`New-TeamViewerDeviceCustomField`](Help/New-TeamViewerDeviceCustomField.md)
+[`New-TeamViewerDeviceCustomFieldConfiguration`](Help/New-TeamViewerDeviceCustomFieldConfiguration.md)
 
 [`New-TeamViewerManagedGroup`](Help/New-TeamViewerManagedGroup.md)
 
-[`Remove-TeamViewerDeviceCustomField`](Help/Remove-TeamViewerDeviceCustomField.md)
+[`Remove-TeamViewerDeviceCustomFieldConfiguration`](Help/Remove-TeamViewerDeviceCustomFieldConfiguration.md)
 
 [`Remove-TeamViewerManagedDevice`](Help/Remove-TeamViewerManagedDevice.md)
 
@@ -181,7 +181,7 @@ Manage the managed groups and managed devices of an account / company / tenant v
 
 [`Remove-TeamViewerPolicyFromManagedGroup`](Help/Remove-TeamViewerPolicyFromManagedGroup.md)
 
-[`Set-TeamViewerDeviceCustomField`](Help/Set-TeamViewerDeviceCustomField.md)
+[`Set-TeamViewerDeviceCustomFieldConfiguration`](Help/Set-TeamViewerDeviceCustomFieldConfiguration.md)
 
 [`Set-TeamViewerManagedDevice`](Help/Set-TeamViewerManagedDevice.md)
 

--- a/Tests/Private/ConvertTo-TeamViewerDeviceCustomFieldConfiguration.Tests.ps1
+++ b/Tests/Private/ConvertTo-TeamViewerDeviceCustomFieldConfiguration.Tests.ps1
@@ -1,9 +1,9 @@
 BeforeAll {
     . "$PSScriptRoot\..\..\Cmdlets\Private\ConvertTo-DateTime.ps1"
-    . "$PSScriptRoot\..\..\Cmdlets\Private\ConvertTo-TeamViewerDeviceCustomField.ps1"
+    . "$PSScriptRoot\..\..\Cmdlets\Private\ConvertTo-TeamViewerDeviceCustomFieldConfiguration.ps1"
 }
 
-Describe 'ConvertTo-TeamViewerDeviceCustomField' {
+Describe 'ConvertTo-TeamViewerDeviceCustomFieldConfiguration' {
     It 'Should map the API properties and type the result' {
         $InputObject = [PSCustomObject]@{
             fieldKeyId  = '00000000-0000-0000-0000-000000000001'
@@ -14,7 +14,7 @@ Describe 'ConvertTo-TeamViewerDeviceCustomField' {
             updatedAt   = '2026-01-02T00:00:00Z'
         }
 
-        $Result = $InputObject | ConvertTo-TeamViewerDeviceCustomField
+        $Result = $InputObject | ConvertTo-TeamViewerDeviceCustomFieldConfiguration
 
         $Result.Id | Should -Be $InputObject.fieldKeyId
         $Result.FieldKey | Should -Be 'AssetTag'
@@ -24,7 +24,7 @@ Describe 'ConvertTo-TeamViewerDeviceCustomField' {
         $Result.CreatedAt | Should -Be ([datetime]'2026-01-01T00:00:00Z')
         $Result.UpdatedAt | Should -BeOfType ([datetime])
         $Result.UpdatedAt | Should -Be ([datetime]'2026-01-02T00:00:00Z')
-        $Result.PSObject.TypeNames | Should -Contain 'TeamViewerPS.DeviceCustomField'
+        $Result.PSObject.TypeNames | Should -Contain 'TeamViewerPS.DeviceCustomFieldConfiguration'
         $Result.ToString() | Should -Be 'AssetTag (00000000-0000-0000-0000-000000000001)'
     }
 
@@ -32,7 +32,7 @@ Describe 'ConvertTo-TeamViewerDeviceCustomField' {
         $Results = @(
             [PSCustomObject]@{ fieldKeyId = 'id1'; fieldKey = 'One' }
             [PSCustomObject]@{ fieldKeyId = 'id2'; fieldKey = 'Two' }
-        ) | ConvertTo-TeamViewerDeviceCustomField
+        ) | ConvertTo-TeamViewerDeviceCustomFieldConfiguration
 
         $Results.Count | Should -Be 2
         $Results.FieldKey | Should -Be @('One', 'Two')

--- a/Tests/Public/Get-TeamViewerDeviceCustomFieldConfiguration.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerDeviceCustomFieldConfiguration.Tests.ps1
@@ -1,22 +1,22 @@
 BeforeAll {
-    . "$PSScriptRoot\..\..\Cmdlets\Public\Get-TeamViewerDeviceCustomField.ps1"
+    . "$PSScriptRoot\..\..\Cmdlets\Public\Get-TeamViewerDeviceCustomFieldConfiguration.ps1"
     @(Get-ChildItem -Path "$PSScriptRoot\..\..\Cmdlets\Private\*.ps1") | ForEach-Object { . $_.FullName }
 
     $testApiToken = [securestring]@{}
     $null = $testApiToken
 }
 
-Describe 'Get-TeamViewerDeviceCustomField' {
+Describe 'Get-TeamViewerDeviceCustomFieldConfiguration' {
     It 'Should list device custom field definitions' {
         Mock Get-TeamViewerApiUri { '//unit.test' }
         Mock Invoke-TeamViewerRestMethod {
             @{ resources = @(@{ fieldKeyId = 'id1'; fieldKey = 'AssetTag'; fieldType = 'string' }) }
         }
 
-        $Result = Get-TeamViewerDeviceCustomField -ApiToken $testApiToken
+        $Result = Get-TeamViewerDeviceCustomFieldConfiguration -ApiToken $testApiToken
 
         $Result.FieldKey | Should -Be 'AssetTag'
-        $Result.PSObject.TypeNames | Should -Contain 'TeamViewerPS.DeviceCustomField'
+        $Result.PSObject.TypeNames | Should -Contain 'TeamViewerPS.DeviceCustomFieldConfiguration'
 
         Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -and

--- a/Tests/Public/New-TeamViewerDeviceCustomFieldConfiguration.Tests.ps1
+++ b/Tests/Public/New-TeamViewerDeviceCustomFieldConfiguration.Tests.ps1
@@ -1,19 +1,19 @@
 BeforeAll {
-    . "$PSScriptRoot\..\..\Cmdlets\Public\New-TeamViewerDeviceCustomField.ps1"
+    . "$PSScriptRoot\..\..\Cmdlets\Public\New-TeamViewerDeviceCustomFieldConfiguration.ps1"
     @(Get-ChildItem -Path "$PSScriptRoot\..\..\Cmdlets\Private\*.ps1") | ForEach-Object { . $_.FullName }
 
     $testApiToken = [securestring]@{}
     $null = $testApiToken
 }
 
-Describe 'New-TeamViewerDeviceCustomField' {
+Describe 'New-TeamViewerDeviceCustomFieldConfiguration' {
     It 'Should create a device custom field definition' {
         Mock Get-TeamViewerApiUri { '//unit.test' }
         Mock Invoke-TeamViewerRestMethod {
             @{ fieldKeyId = 'id1'; fieldKey = 'AssetTag'; fieldType = 'string'; description = 'Device asset tag' }
         }
 
-        $Result = New-TeamViewerDeviceCustomField -ApiToken $testApiToken -FieldKey 'AssetTag' -Description 'Device asset tag'
+        $Result = New-TeamViewerDeviceCustomFieldConfiguration -ApiToken $testApiToken -FieldKey 'AssetTag' -Description 'Device asset tag'
 
         $Result.FieldKey | Should -Be 'AssetTag'
 
@@ -30,7 +30,7 @@ Describe 'New-TeamViewerDeviceCustomField' {
         Mock Get-TeamViewerApiUri { '//unit.test' }
         Mock Invoke-TeamViewerRestMethod { }
 
-        New-TeamViewerDeviceCustomField -ApiToken $testApiToken -FieldKey 'AssetTag' -WhatIf
+        New-TeamViewerDeviceCustomFieldConfiguration -ApiToken $testApiToken -FieldKey 'AssetTag' -WhatIf
 
         Should -Invoke Invoke-TeamViewerRestMethod -Times 0 -Scope It
     }

--- a/Tests/Public/Remove-TeamViewerDeviceCustomFieldConfiguration.Tests.ps1
+++ b/Tests/Public/Remove-TeamViewerDeviceCustomFieldConfiguration.Tests.ps1
@@ -1,17 +1,17 @@
 BeforeAll {
-    . "$PSScriptRoot\..\..\Cmdlets\Public\Remove-TeamViewerDeviceCustomField.ps1"
+    . "$PSScriptRoot\..\..\Cmdlets\Public\Remove-TeamViewerDeviceCustomFieldConfiguration.ps1"
     @(Get-ChildItem -Path "$PSScriptRoot\..\..\Cmdlets\Private\*.ps1") | ForEach-Object { . $_.FullName }
 
     $testApiToken = [securestring]@{}
     $null = $testApiToken
 }
 
-Describe 'Remove-TeamViewerDeviceCustomField' {
+Describe 'Remove-TeamViewerDeviceCustomFieldConfiguration' {
     It 'Should delete a device custom field definition' {
         Mock Get-TeamViewerApiUri { '//unit.test' }
         Mock Invoke-TeamViewerRestMethod { }
 
-        Remove-TeamViewerDeviceCustomField -ApiToken $testApiToken -Id '00000000-0000-0000-0000-000000000001'
+        Remove-TeamViewerDeviceCustomFieldConfiguration -ApiToken $testApiToken -Id '00000000-0000-0000-0000-000000000001'
 
         Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $Uri -eq '//unit.test/device-custom-fields/00000000-0000-0000-0000-000000000001' -and
@@ -20,14 +20,14 @@ Describe 'Remove-TeamViewerDeviceCustomField' {
     }
 
     It 'Should reject an invalid field ID' {
-        { Remove-TeamViewerDeviceCustomField -ApiToken $testApiToken -Id 'invalid' } | Should -Throw
+        { Remove-TeamViewerDeviceCustomFieldConfiguration -ApiToken $testApiToken -Id 'invalid' } | Should -Throw
     }
 
     It 'Should accept pipeline input' {
         Mock Get-TeamViewerApiUri { '//unit.test' }
         Mock Invoke-TeamViewerRestMethod { }
 
-        '00000000-0000-0000-0000-000000000001' | Remove-TeamViewerDeviceCustomField -ApiToken $testApiToken
+        '00000000-0000-0000-0000-000000000001' | Remove-TeamViewerDeviceCustomFieldConfiguration -ApiToken $testApiToken
 
         Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $Uri -eq '//unit.test/device-custom-fields/00000000-0000-0000-0000-000000000001' -and
@@ -39,7 +39,7 @@ Describe 'Remove-TeamViewerDeviceCustomField' {
         Mock Get-TeamViewerApiUri { '//unit.test' }
         Mock Invoke-TeamViewerRestMethod { }
 
-        Remove-TeamViewerDeviceCustomField -ApiToken $testApiToken -Id '00000000-0000-0000-0000-000000000001' -WhatIf
+        Remove-TeamViewerDeviceCustomFieldConfiguration -ApiToken $testApiToken -Id '00000000-0000-0000-0000-000000000001' -WhatIf
 
         Should -Invoke Invoke-TeamViewerRestMethod -Times 0 -Scope It
     }

--- a/Tests/Public/Set-TeamViewerDeviceCustomFieldConfiguration.Tests.ps1
+++ b/Tests/Public/Set-TeamViewerDeviceCustomFieldConfiguration.Tests.ps1
@@ -1,19 +1,19 @@
 BeforeAll {
-    . "$PSScriptRoot\..\..\Cmdlets\Public\Set-TeamViewerDeviceCustomField.ps1"
+    . "$PSScriptRoot\..\..\Cmdlets\Public\Set-TeamViewerDeviceCustomFieldConfiguration.ps1"
     @(Get-ChildItem -Path "$PSScriptRoot\..\..\Cmdlets\Private\*.ps1") | ForEach-Object { . $_.FullName }
 
     $testApiToken = [securestring]@{}
     $null = $testApiToken
 }
 
-Describe 'Set-TeamViewerDeviceCustomField' {
+Describe 'Set-TeamViewerDeviceCustomFieldConfiguration' {
     It 'Should update a device custom field definition' {
         Mock Get-TeamViewerApiUri { '//unit.test' }
         Mock Invoke-TeamViewerRestMethod {
             @{ fieldKeyId = '00000000-0000-0000-0000-000000000001'; fieldKey = 'AssetTag'; fieldType = 'string' }
         }
 
-        $Result = Set-TeamViewerDeviceCustomField -ApiToken $testApiToken -Id '00000000-0000-0000-0000-000000000001' -FieldKey 'AssetTag' -Description ''
+        $Result = Set-TeamViewerDeviceCustomFieldConfiguration -ApiToken $testApiToken -Id '00000000-0000-0000-0000-000000000001' -FieldKey 'AssetTag' -Description ''
 
         $Result.FieldKey | Should -Be 'AssetTag'
 
@@ -26,14 +26,14 @@ Describe 'Set-TeamViewerDeviceCustomField' {
     }
 
     It 'Should reject an invalid field ID' {
-        { Set-TeamViewerDeviceCustomField -ApiToken $testApiToken -Id 'invalid' -FieldKey 'AssetTag' } | Should -Throw
+        { Set-TeamViewerDeviceCustomFieldConfiguration -ApiToken $testApiToken -Id 'invalid' -FieldKey 'AssetTag' } | Should -Throw
     }
 
     It 'Should not call the API with WhatIf' {
         Mock Get-TeamViewerApiUri { '//unit.test' }
         Mock Invoke-TeamViewerRestMethod { }
 
-        Set-TeamViewerDeviceCustomField -ApiToken $testApiToken -Id '00000000-0000-0000-0000-000000000001' -FieldKey 'AssetTag' -WhatIf
+        Set-TeamViewerDeviceCustomFieldConfiguration -ApiToken $testApiToken -Id '00000000-0000-0000-0000-000000000001' -FieldKey 'AssetTag' -WhatIf
 
         Should -Invoke Invoke-TeamViewerRestMethod -Times 0 -Scope It
     }


### PR DESCRIPTION
## Description

Refactors all DeviceCustomField-related cmdlets and supporting files to use the more descriptive name `DeviceCustomFieldConfiguration`.

## Changes

### Renamed Files (14 total)
- **Public cmdlets (4)**: Get/New/Set/Remove-TeamViewerDeviceCustomField → ...DeviceCustomFieldConfiguration
- **Private functions (1)**: ConvertTo-TeamViewerDeviceCustomField → ConvertTo-TeamViewerDeviceCustomFieldConfiguration
- **Test files (5)**: All tests renamed with Configuration suffix
- **Help documentation (4)**: All help markdown files renamed with Configuration suffix

### Content Updates
- Updated all function definitions and calls with new names
- Updated type name: `TeamViewerPS.DeviceCustomField` → `TeamViewerPS.DeviceCustomFieldConfiguration`
- Updated `[OutputType()]` declarations
- Updated CHANGELOG.md with new command references
- Updated Docs/TeamViewerPS.md with corrected links

## Testing & Validation

✅ All 12 Pester tests pass  
✅ PSScriptAnalyzer linting passes  
✅ No remaining references to old function names  
✅ All new function names properly documented

## Breaking Changes

This is a **breaking change** for users of the DeviceCustomField cmdlets. They must update their scripts to use the new command names:
- `Get-TeamViewerDeviceCustomField` → `Get-TeamViewerDeviceCustomFieldConfiguration`
- `New-TeamViewerDeviceCustomField` → `New-TeamViewerDeviceCustomFieldConfiguration`
- `Set-TeamViewerDeviceCustomField` → `Set-TeamViewerDeviceCustomFieldConfiguration`
- `Remove-TeamViewerDeviceCustomField` → `Remove-TeamViewerDeviceCustomFieldConfiguration`