### PR TITLE
Harmonize object parameter types

### DIFF
--- a/Cmdlets/Private/ConvertTo-TeamViewerAccount.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerAccount.ps1
@@ -1,7 +1,7 @@
 function ConvertTo-TeamViewerAccount {
     param(
         [Parameter(ValueFromPipeline)]
-        [PSObject]
+        [object]
         $InputObject
     )
 

--- a/Cmdlets/Private/ConvertTo-TeamViewerAuditEvent.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerAuditEvent.ps1
@@ -1,7 +1,7 @@
 function ConvertTo-TeamViewerAuditEvent {
     param(
         [Parameter(ValueFromPipeline)]
-        [PSObject]
+        [object]
         $InputObject
     )
 

--- a/Cmdlets/Private/ConvertTo-TeamViewerCompany.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerCompany.ps1
@@ -1,7 +1,7 @@
 function ConvertTo-TeamViewerCompany {
     param(
         [Parameter(ValueFromPipeline)]
-        [PSObject]
+        [object]
         $InputObject
     )
 

--- a/Cmdlets/Private/ConvertTo-TeamViewerConnectionReport.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerConnectionReport.ps1
@@ -1,7 +1,7 @@
 function ConvertTo-TeamViewerConnectionReport {
     param(
         [Parameter(ValueFromPipeline)]
-        [PSObject]
+        [object]
         $InputObject
     )
 

--- a/Cmdlets/Private/ConvertTo-TeamViewerContact.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerContact.ps1
@@ -1,7 +1,7 @@
 function ConvertTo-TeamViewerContact {
     param(
         [Parameter(ValueFromPipeline)]
-        [PSObject]
+        [object]
         $InputObject
     )
 

--- a/Cmdlets/Private/ConvertTo-TeamViewerDevice.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerDevice.ps1
@@ -1,7 +1,7 @@
 function ConvertTo-TeamViewerDevice {
     param(
         [Parameter(ValueFromPipeline)]
-        [PSObject]
+        [object]
         $InputObject
     )
 

--- a/Cmdlets/Private/ConvertTo-TeamViewerDeviceCustomFieldConfiguration.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerDeviceCustomFieldConfiguration.ps1
@@ -1,7 +1,7 @@
 function ConvertTo-TeamViewerDeviceCustomFieldConfiguration {
     param(
         [Parameter(ValueFromPipeline)]
-        [PSObject]
+        [object]
         $InputObject
     )
 

--- a/Cmdlets/Private/ConvertTo-TeamViewerGroup.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerGroup.ps1
@@ -1,7 +1,7 @@
 function ConvertTo-TeamViewerGroup {
     param(
         [Parameter(ValueFromPipeline)]
-        [PSObject]
+        [object]
         $InputObject
     )
 

--- a/Cmdlets/Private/ConvertTo-TeamViewerGroupShare.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerGroupShare.ps1
@@ -1,7 +1,7 @@
 function ConvertTo-TeamViewerGroupShare {
     param(
         [Parameter(ValueFromPipeline)]
-        [PSObject]
+        [object]
         $InputObject
     )
 

--- a/Cmdlets/Private/ConvertTo-TeamViewerLicense.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerLicense.ps1
@@ -1,7 +1,7 @@
 function ConvertTo-TeamViewerLicense {
     param(
         [Parameter(ValueFromPipeline)]
-        [PSObject]
+        [object]
         $InputObject
     )
 

--- a/Cmdlets/Private/ConvertTo-TeamViewerLicenseInformation.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerLicenseInformation.ps1
@@ -1,7 +1,7 @@
 function ConvertTo-TeamViewerLicenseInformation {
     param(
         [Parameter(ValueFromPipeline)]
-        [PSObject]
+        [object]
         $InputObject
     )
 

--- a/Cmdlets/Private/ConvertTo-TeamViewerManagedDevice.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerManagedDevice.ps1
@@ -1,7 +1,7 @@
 function ConvertTo-TeamViewerManagedDevice {
     param(
         [Parameter(ValueFromPipeline)]
-        [PSObject]
+        [object]
         $InputObject
     )
 

--- a/Cmdlets/Private/ConvertTo-TeamViewerManagedGroup.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerManagedGroup.ps1
@@ -1,7 +1,7 @@
 function ConvertTo-TeamViewerManagedGroup {
     param(
         [Parameter(ValueFromPipeline)]
-        [PSObject]
+        [object]
         $InputObject
     )
 

--- a/Cmdlets/Private/ConvertTo-TeamViewerManager.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerManager.ps1
@@ -1,7 +1,7 @@
 function ConvertTo-TeamViewerManager {
     param(
         [Parameter(ValueFromPipeline)]
-        [PSObject]
+        [object]
         $InputObject,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'GroupManager')]

--- a/Cmdlets/Private/ConvertTo-TeamViewerPolicy.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerPolicy.ps1
@@ -1,7 +1,7 @@
 function ConvertTo-TeamViewerPolicy {
     param(
         [Parameter(ValueFromPipeline)]
-        [PSObject]
+        [object]
         $InputObject
     )
 

--- a/Cmdlets/Private/ConvertTo-TeamViewerPredefinedRole.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerPredefinedRole.ps1
@@ -1,7 +1,7 @@
 function ConvertTo-TeamViewerPredefinedRole {
     param(
         [Parameter(ValueFromPipeline = $true)]
-        [PSObject]
+        [object]
         $InputObject
     )
 

--- a/Cmdlets/Private/ConvertTo-TeamViewerRole.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerRole.ps1
@@ -1,7 +1,7 @@
 function ConvertTo-TeamViewerRole {
     param(
         [Parameter(ValueFromPipeline)]
-        [PSObject]
+        [object]
         $InputObject
     )
 

--- a/Cmdlets/Private/ConvertTo-TeamViewerRoleAssignedUser.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerRoleAssignedUser.ps1
@@ -1,7 +1,7 @@
 function ConvertTo-TeamViewerRoleAssignedUser {
     param(
         [Parameter(ValueFromPipeline)]
-        [PSObject]
+        [object]
         $InputObject
     )
 

--- a/Cmdlets/Private/ConvertTo-TeamViewerRoleAssignedUserGroup.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerRoleAssignedUserGroup.ps1
@@ -1,7 +1,7 @@
 function ConvertTo-TeamViewerRoleAssignedUserGroup {
     param(
         [Parameter(ValueFromPipeline)]
-        [PSObject]
+        [object]
         $InputObject
     )
 

--- a/Cmdlets/Private/ConvertTo-TeamViewerSsoDomain.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerSsoDomain.ps1
@@ -1,7 +1,7 @@
 function ConvertTo-TeamViewerSsoDomain {
     param(
         [Parameter(ValueFromPipeline)]
-        [PSObject]
+        [object]
         $InputObject
     )
 

--- a/Cmdlets/Private/ConvertTo-TeamViewerUser.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerUser.ps1
@@ -1,7 +1,7 @@
 function ConvertTo-TeamViewerUser {
     param(
         [Parameter(ValueFromPipeline)]
-        [PSObject]
+        [object]
         $InputObject,
 
         [Parameter()]

--- a/Cmdlets/Private/ConvertTo-TeamViewerUserGroup.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerUserGroup.ps1
@@ -1,7 +1,7 @@
 function ConvertTo-TeamViewerUserGroup {
     param(
         [Parameter(ValueFromPipeline)]
-        [PSObject]
+        [object]
         $InputObject
     )
 

--- a/Cmdlets/Private/ConvertTo-TeamViewerUserGroupAssignedRole.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerUserGroupAssignedRole.ps1
@@ -1,7 +1,7 @@
 function ConvertTo-TeamViewerRoleAssignedUserGroup {
     param(
         [Parameter(ValueFromPipeline)]
-        [PSObject]
+        [object]
         $InputObject
     )
 

--- a/Cmdlets/Private/ConvertTo-TeamViewerUserGroupMember.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerUserGroupMember.ps1
@@ -1,7 +1,7 @@
 function ConvertTo-TeamViewerUserGroupMember {
     param(
         [Parameter(ValueFromPipeline)]
-        [PSObject]
+        [object]
         $InputObject
     )
 

--- a/Cmdlets/Private/Invoke-TeamViewerRestMethod.ps1
+++ b/Cmdlets/Private/Invoke-TeamViewerRestMethod.ps1
@@ -14,7 +14,7 @@ function Invoke-TeamViewerRestMethod {
         [System.Collections.IDictionary]
         $Headers,
 
-        [System.Object]
+        [object]
         $Body,
 
         [string]

--- a/Cmdlets/Private/Resolve-TeamViewerRoleId.ps1
+++ b/Cmdlets/Private/Resolve-TeamViewerRoleId.ps1
@@ -2,7 +2,7 @@
 function Resolve-TeamViewerRoleId {
     param(
         [Parameter(ValueFromPipeline = $true, Mandatory = $true)]
-        [Object]
+        [object]
         $Role
     )
 


### PR DESCRIPTION
## Summary

Harmonize flexible object parameter declarations across private cmdlets.

- Replace converter `[PSObject]` input declarations with `[object]` because the converters only consume ordinary properties.
- Normalize `[System.Object]` and `[Object]` aliases to `[object]`.
- Preserve intentional `.PSObject` type-name and property introspection.

## Validation

- `Invoke-Pester -Path .`: 1,265 passed
- `Invoke-ScriptAnalyzer -Path . -Recurse -Settings .\Linters\PSScriptAnalyzer.psd1`: passed