### PR TITLE
Harmonize converter output contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,7 +126,7 @@
 - Adds `Export-TeamViewerSystemInformation` to create zip file for support.
 - Adds `Set-TeamViewerPSProxy` and `Remove-TeamViewerPSProxy` to set proxy to access web API.
 - Adds `Get-TeamViewerInstallationDirectory` to return installation directory.
-- Adds `Get-TeamViewerCustomModuleId` to return custom module ID.
+- Adds `Get-TeamViewerCustomModuleId` to return custom module Id.
 - Adds `Get-TeamViewerLogFilePath` to return log file paths for different logs present.
 - Adds `Remove-TeamViewerPolicyFromManagedDevice` to remove policies from managed devices.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Adds `OutputType` to public commands.
 - Adds `CmdletBinding` to public commands.
 - Standardizes pipeline emission on Write-Output.
+- Harmonizes private converter output properties and value types
 - Creates, expands, and hardens all private functions tests.
 - Automate release module versioning.
 

--- a/Cmdlets/Private/ConvertTo-TeamViewerAccount.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerAccount.ps1
@@ -7,23 +7,20 @@ function ConvertTo-TeamViewerAccount {
 
     process {
         $Properties = @{
-            Name             = $InputObject.name
-            Email            = $InputObject.email
-            UserId           = $InputObject.userid
-            CompanyName      = $InputObject.company_name
-            IsEmailValidated = $InputObject.email_validated
-            EmailLanguage    = $InputObject.email_language
+            Id                = $InputObject.userid
+            Name              = $InputObject.name
+            Email             = $InputObject.email
+            Email_IsValidated = $InputObject.email_validated
+            Email_Language    = $InputObject.email_language
+            Company_Name      = $InputObject.company_name
         }
 
         if ($InputObject.email_language -and $InputObject.email_language -ne 'auto') {
-            $Properties['EmailLanguage'] = [System.Globalization.CultureInfo]($InputObject.email_language)
+            $Properties['Email_Language'] = [System.Globalization.CultureInfo]($InputObject.email_language)
         }
 
         $Result = New-Object -TypeName PSObject -Property $Properties
         $Result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.Account')
-        $Result | Add-Member -MemberType ScriptMethod -Name 'ToString' -Force -Value {
-            "$($this.Name) <$($this.Email)>"
-        }
 
         Write-Output $Result
     }

--- a/Cmdlets/Private/ConvertTo-TeamViewerAuditEvent.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerAuditEvent.ps1
@@ -9,17 +9,14 @@ function ConvertTo-TeamViewerAuditEvent {
         $Properties = @{
             Name         = $InputObject.EventName
             Type         = $InputObject.EventType
-            Timestamp    = $InputObject.Timestamp | ConvertTo-DateTime
             Author       = $InputObject.Author
             AffectedItem = $InputObject.AffectedItem
-            EventDetails = $InputObject.EventDetails
+            Details      = $InputObject.EventDetails
+            CreatedAt    = $InputObject.Timestamp | ConvertTo-DateTime
         }
 
         $Result = New-Object -TypeName PSObject -Property $Properties
         $Result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.AuditEvent')
-        $Result | Add-Member -MemberType ScriptMethod -Name 'ToString' -Force -Value {
-            "[$($this.Timestamp)] $($this.Name) ($($this.Type))"
-        }
 
         Write-Output $Result
     }

--- a/Cmdlets/Private/ConvertTo-TeamViewerCompany.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerCompany.ps1
@@ -7,9 +7,9 @@ function ConvertTo-TeamViewerCompany {
 
     process {
         $Properties = @{
-            CompanyId   = [int]$InputObject.companyId
-            CompanyName = $InputObject.companyName
-            CreatedAt   = $null
+            Id        = [int]$InputObject.companyId
+            Name      = $InputObject.companyName
+            CreatedAt = $null
         }
 
         if ($InputObject.createdAt) {
@@ -18,9 +18,6 @@ function ConvertTo-TeamViewerCompany {
 
         $Result = New-Object -TypeName PSObject -Property $Properties
         $Result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.Company')
-        $Result | Add-Member -MemberType ScriptMethod -Name 'ToString' -Force -Value {
-            "$($this.CompanyName)"
-        }
 
         Write-Output $Result
     }

--- a/Cmdlets/Private/ConvertTo-TeamViewerConnectionReport.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerConnectionReport.ps1
@@ -7,21 +7,21 @@ function ConvertTo-TeamViewerConnectionReport {
 
     process {
         $Properties = @{
-            Id                 = $InputObject.id
-            UserId             = $InputObject.userid
-            UserName           = $InputObject.username
-            DeviceId           = $InputObject.deviceid
-            DeviceName         = $InputObject.devicename
-            GroupId            = $InputObject.groupid
-            GroupName          = $InputObject.groupname
-            SupportSessionType = [TeamViewerConnectionReportSessionType]$InputObject.support_session_type
-            StartDate          = $InputObject.start_date | ConvertTo-DateTime
-            EndDate            = $InputObject.end_date | ConvertTo-DateTime
-            SessionCode        = $InputObject.session_code
-            Fee                = $InputObject.fee
-            BillingState       = $InputObject.billing_state
-            Currency           = $InputObject.currency
-            Notes              = $InputObject.notes
+            Id               = $InputObject.id
+            User_Id          = $InputObject.userid
+            User_Name        = $InputObject.username
+            Device_Id        = $InputObject.deviceid
+            Device_Name      = $InputObject.devicename
+            Group_Id         = $InputObject.groupid
+            Group_Name       = $InputObject.groupname
+            Session_Type     = [TeamViewerConnectionReportSessionType]$InputObject.support_session_type
+            Datetime_Start   = $InputObject.start_date | ConvertTo-DateTime
+            Datetime_End     = $InputObject.end_date | ConvertTo-DateTime
+            SessionCode      = $InputObject.session_code
+            Billing_Fee      = $InputObject.fee
+            Billing_State    = $InputObject.billing_state
+            Billing_Currency = $InputObject.currency
+            Notes            = $InputObject.notes
         }
 
         $Result = New-Object -TypeName PSObject -Property $Properties

--- a/Cmdlets/Private/ConvertTo-TeamViewerContact.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerContact.ps1
@@ -7,21 +7,18 @@ function ConvertTo-TeamViewerContact {
 
     process {
         $Properties = @{
-            Id                = $InputObject.contact_id
-            UserId            = $InputObject.user_id
-            GroupId           = $InputObject.groupid
-            Name              = $InputObject.name
-            Description       = $InputObject.description
-            OnlineState       = $InputObject.online_state
-            ProfilePictureUrl = $InputObject.profilepicture_url
-            SupportedFeatures = $InputObject.supported_features
+            Id                 = $InputObject.contact_id
+            Name               = $InputObject.name
+            Description        = $InputObject.description
+            User_Id            = $InputObject.user_id
+            Group_Id           = $InputObject.groupid
+            OnlineState        = $InputObject.online_state
+            ProfilePicture_Url = $InputObject.profilepicture_url
+            Features_Supported = $InputObject.supported_features
         }
 
         $Result = New-Object -TypeName PSObject -Property $Properties
         $Result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.Contact')
-        $Result | Add-Member -MemberType ScriptMethod -Name 'ToString' -Force -Value {
-            "$($this.Name)"
-        }
 
         Write-Output $Result
     }

--- a/Cmdlets/Private/ConvertTo-TeamViewerDevice.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerDevice.ps1
@@ -7,30 +7,28 @@ function ConvertTo-TeamViewerDevice {
 
     process {
         $RemoteControlId = $InputObject.remotecontrol_id | Select-String -Pattern 'r(\d+)' | ForEach-Object { $_.Matches.Groups[1].Value }
+
         $Properties = @{
-            Id                         = $InputObject.device_id
-            TeamViewerId               = $RemoteControlId
-            GroupId                    = $InputObject.groupid
-            Name                       = $InputObject.alias
-            Description                = $InputObject.description
-            OnlineState                = $InputObject.online_state
-            IsAssignedToCurrentAccount = $InputObject.assigned_to
-            SupportedFeatures          = $InputObject.supported_features
+            Id                 = $InputObject.device_id
+            TeamViewerId       = $RemoteControlId
+            Name               = $InputObject.alias
+            Description        = $InputObject.description
+            OnlineState        = $InputObject.online_state
+            Group_Id           = $InputObject.groupid
+            Assigned_To        = $InputObject.assigned_to
+            Features_Supported = $InputObject.supported_features
         }
 
         if ($InputObject.policy_id) {
-            $Properties['PolicyId'] = $InputObject.policy_id
+            $Properties['Policy_Id'] = $InputObject.policy_id
         }
 
         if ($InputObject.last_seen) {
-            $Properties['LastSeenAt'] = [datetime]($InputObject.last_seen)
+            $Properties['LastSeen_At'] = [datetime]($InputObject.last_seen)
         }
 
         $Result = New-Object -TypeName PSObject -Property $Properties
         $Result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.Device')
-        $Result | Add-Member -MemberType ScriptMethod -Name 'ToString' -Force -Value {
-            "$($this.Name)"
-        }
 
         Write-Output $Result
     }

--- a/Cmdlets/Private/ConvertTo-TeamViewerDeviceCustomField.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerDeviceCustomField.ps1
@@ -7,16 +7,12 @@ function ConvertTo-TeamViewerDeviceCustomField {
 
     process {
         $Properties = @{
-            FieldKeyId = $InputObject.fieldKeyId
-            Value      = $InputObject.value
+            Id    = $InputObject.fieldKeyId
+            Value = $InputObject.value
         }
 
         $Result = New-Object -TypeName PSObject -Property $Properties
         $Result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.DeviceCustomField')
-
-        $Result | Add-Member -MemberType ScriptMethod -Name 'ToString' -Force -Value {
-            '{0}' -f $this.Value
-        }
 
         Write-Output $Result
     }

--- a/Cmdlets/Private/ConvertTo-TeamViewerDeviceCustomFieldConfiguration.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerDeviceCustomFieldConfiguration.ps1
@@ -8,7 +8,7 @@ function ConvertTo-TeamViewerDeviceCustomFieldConfiguration {
     process {
         $Properties = @{
             Id          = $InputObject.fieldKeyId
-            Key         = $InputObject.fieldKey
+            Name        = $InputObject.fieldKey
             Type        = $InputObject.fieldType
             Description = $InputObject.description
             CreatedAt   = $InputObject.createdAt | ConvertTo-DateTime

--- a/Cmdlets/Private/ConvertTo-TeamViewerDeviceCustomFieldConfiguration.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerDeviceCustomFieldConfiguration.ps1
@@ -8,8 +8,8 @@ function ConvertTo-TeamViewerDeviceCustomFieldConfiguration {
     process {
         $Properties = @{
             Id          = $InputObject.fieldKeyId
-            FieldKey    = $InputObject.fieldKey
-            FieldType   = $InputObject.fieldType
+            Key         = $InputObject.fieldKey
+            Type        = $InputObject.fieldType
             Description = $InputObject.description
             CreatedAt   = $InputObject.createdAt | ConvertTo-DateTime
             UpdatedAt   = $InputObject.updatedAt | ConvertTo-DateTime
@@ -17,10 +17,6 @@ function ConvertTo-TeamViewerDeviceCustomFieldConfiguration {
 
         $Result = New-Object -TypeName PSObject -Property $Properties
         $Result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.DeviceCustomFieldConfiguration')
-
-        $Result | Add-Member -MemberType ScriptMethod -Name 'ToString' -Force -Value {
-            '{0} ({1})' -f $this.FieldKey, $this.Id
-        }
 
         Write-Output $Result
     }

--- a/Cmdlets/Private/ConvertTo-TeamViewerGroup.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerGroup.ps1
@@ -10,14 +10,14 @@ function ConvertTo-TeamViewerGroup {
             Id          = $InputObject.id
             Name        = $InputObject.name
             Permissions = $InputObject.permissions
-            PolicyId    = $InputObject.policy_id
-            SharedWith  = @($InputObject.shared_with | ConvertTo-TeamViewerGroupShare)
+            Policy_Id   = $InputObject.policy_id
+            Shared_With = @($InputObject.shared_with | ConvertTo-TeamViewerGroupShare)
         }
 
         if ($InputObject.owner) {
             $Properties.Owner = [pscustomobject]@{
-                UserId = $InputObject.owner.userid
-                Name   = $InputObject.owner.name
+                Id   = $InputObject.owner.userid
+                Name = $InputObject.owner.name
             }
         }
 

--- a/Cmdlets/Private/ConvertTo-TeamViewerGroupShare.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerGroupShare.ps1
@@ -7,16 +7,13 @@ function ConvertTo-TeamViewerGroupShare {
 
     process {
         $Properties = @{
-            UserId      = $InputObject.userid
+            Id          = $InputObject.userid
             Name        = $InputObject.name
             Permissions = $InputObject.permissions
         }
 
         $Result = New-Object -TypeName PSObject -Property $Properties
         $Result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.GroupShare')
-        $Result | Add-Member -MemberType ScriptMethod -Name 'ToString' -Force -Value {
-            "$($this.UserId)"
-        }
 
         Write-Output $Result
     }

--- a/Cmdlets/Private/ConvertTo-TeamViewerLicense.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerLicense.ps1
@@ -7,16 +7,13 @@ function ConvertTo-TeamViewerLicense {
 
     process {
         $Properties = @{
-            CompanyId         = [int]$InputObject.companyId
-            CompanyName       = $InputObject.companyName
-            AvailableLicenses = @($InputObject.available_licenses | ConvertTo-TeamViewerLicenseInformation)
+            Id                 = [int]$InputObject.companyId
+            Name               = $InputObject.companyName
+            Licenses_Available = @($InputObject.available_licenses | ConvertTo-TeamViewerLicenseInformation)
         }
 
         $Result = New-Object -TypeName PSObject -Property $Properties
         $Result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.License')
-        $Result | Add-Member -MemberType ScriptMethod -Name 'ToString' -Force -Value {
-            "$($this.CompanyName)"
-        }
 
         Write-Output $Result
     }

--- a/Cmdlets/Private/ConvertTo-TeamViewerLicenseInformation.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerLicenseInformation.ps1
@@ -7,16 +7,16 @@ function ConvertTo-TeamViewerLicenseInformation {
 
     process {
         $Properties = @{
-            LicenseName      = $InputObject.licenseName
-            Version          = [int]$InputObject.version
-            Type             = $InputObject.type
-            LicenseId        = [guid]$InputObject.licenseId
-            IsActive         = [bool]$InputObject.isActive
-            AiCredits        = [int]$InputObject.aiCredits
-            ManagedDevices   = [int]$InputObject.managedDevices
-            AssignedUsers    = [int]$InputObject.assignedUsers
+            Id               = [guid]$InputObject.licenseId
+            Name             = $InputObject.licenseName
             DisplayName      = $InputObject.displayName
             Details          = $InputObject.details
+            Type             = $InputObject.type
+            Version          = [int]$InputObject.version
+            IsActive         = [bool]$InputObject.isActive
+            AssignedUsers    = [int]$InputObject.assignedUsers
+            ManagedDevices   = [int]$InputObject.managedDevices
+            AiCredits        = [int]$InputObject.aiCredits
             NumberOfChannels = [int]$InputObject.numberOfChannels
             MaxAssignments   = [int]$InputObject.maxAssignments
             TotalTechnicians = [int]$InputObject.totalTechnicians
@@ -24,9 +24,6 @@ function ConvertTo-TeamViewerLicenseInformation {
 
         $Result = New-Object -TypeName PSObject -Property $Properties
         $Result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.LicenseInformation')
-        $Result | Add-Member -MemberType ScriptMethod -Name 'ToString' -Force -Value {
-            "$($this.LicenseName)"
-        }
 
         Write-Output $Result
     }

--- a/Cmdlets/Private/ConvertTo-TeamViewerManagedDevice.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerManagedDevice.ps1
@@ -8,17 +8,17 @@ function ConvertTo-TeamViewerManagedDevice {
     process {
         $Properties = @{
             Id           = [guid]$InputObject.id
-            Name         = $InputObject.name
             TeamViewerId = $InputObject.TeamViewerId
+            Name         = $InputObject.name
             IsOnline     = $InputObject.isOnline
         }
 
         if ($InputObject.last_seen) {
-            $Properties['LastSeenAt'] = Get-Date -Date $InputObject.last_seen
+            $Properties['LastSeen_At'] = Get-Date -Date $InputObject.last_seen
         }
 
         if ($InputObject.teamviewerPolicyId) {
-            $Properties['PolicyId'] = [guid]$InputObject.teamviewerPolicyId
+            $Properties['Policy_Id'] = [guid]$InputObject.teamviewerPolicyId
         }
 
         $Result = New-Object -TypeName PSObject -Property $Properties

--- a/Cmdlets/Private/ConvertTo-TeamViewerManagedGroup.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerManagedGroup.ps1
@@ -12,7 +12,7 @@ function ConvertTo-TeamViewerManagedGroup {
         }
 
         if ($InputObject.policy_id) {
-            $Properties['PolicyId'] = $InputObject.policy_id
+            $Properties['Policy_Id'] = $InputObject.policy_id
         }
 
         $Result = New-Object -TypeName PSObject -Property $Properties

--- a/Cmdlets/Private/ConvertTo-TeamViewerManager.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerManager.ps1
@@ -15,27 +15,27 @@ function ConvertTo-TeamViewerManager {
 
     process {
         $Properties = @{
-            Id          = [guid]$InputObject.id
-            ManagerType = $InputObject.type
-            Name        = $InputObject.name
-            Permissions = $InputObject.permissions
+            Id           = [guid]$InputObject.id
+            Name         = $InputObject.name
+            Manager_Type = $InputObject.type
+            Permissions  = $InputObject.permissions
         }
 
         switch ($InputObject.type) {
             'account' {
-                $Properties.AccountId = $InputObject.accountId
+                $Properties.User_Id = $InputObject.accountId
             }
             'company' {
-                $Properties.CompanyId = $InputObject.companyId
+                $Properties.Company_Id = $InputObject.companyId
             }
         }
 
         switch ($PsCmdlet.ParameterSetName) {
             'GroupManager' {
-                $Properties.GroupId = $GroupId
+                $Properties.Group_Id = $GroupId
             }
             'DeviceManager' {
-                $Properties.DeviceId = $DeviceId
+                $Properties.Device_Id = $DeviceId
             }
         }
 

--- a/Cmdlets/Private/ConvertTo-TeamViewerPredefinedRole.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerPredefinedRole.ps1
@@ -7,14 +7,11 @@ function ConvertTo-TeamViewerPredefinedRole {
 
     process {
         $Properties = @{
-            PredefinedRoleId = $InputObject.PredefinedUserRoleId
+            Role_Id = $InputObject.PredefinedUserRoleId
         }
 
         $Result = New-Object -TypeName PSObject -Property $Properties
         $Result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.PredefinedRole')
-        $Result | Add-Member -MemberType ScriptMethod -Name 'ToString' -Force -Value {
-            "[$($this.PredefinedRoleID)]"
-        }
 
         Write-Output $Result
     }

--- a/Cmdlets/Private/ConvertTo-TeamViewerRole.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerRole.ps1
@@ -7,7 +7,7 @@ function ConvertTo-TeamViewerRole {
 
     process {
         $Properties = @{
-            ID   = $InputObject.Id
+            Id   = $InputObject.Id
             Name = $InputObject.Name
         }
 

--- a/Cmdlets/Private/ConvertTo-TeamViewerRole.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerRole.ps1
@@ -7,8 +7,8 @@ function ConvertTo-TeamViewerRole {
 
     process {
         $Properties = @{
-            RoleName = $InputObject.Name
-            RoleID   = $InputObject.Id
+            ID   = $InputObject.Id
+            Name = $InputObject.Name
         }
 
         if ($InputObject.Permissions) {
@@ -19,11 +19,7 @@ function ConvertTo-TeamViewerRole {
 
         $Result = New-Object -TypeName PSObject -Property $Properties
         $Result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.Role')
-        $Result | Add-Member -MemberType ScriptMethod -Name 'ToString' -Force -Value {
-            "[$($this.RoleName)] [$($this.RoleID)] $($this.Permissions))"
-        }
 
         Write-Output $Result
     }
 }
-

--- a/Cmdlets/Private/ConvertTo-TeamViewerRoleAssignedUser.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerRoleAssignedUser.ps1
@@ -7,7 +7,7 @@ function ConvertTo-TeamViewerRoleAssignedUser {
 
     process {
         $Properties = @{
-            AssignedUsers = ($InputObject.trim('u'))
+            Assigned_Users = ($InputObject.trim('u'))
         }
 
         $Result = New-Object -TypeName PSObject -Property $Properties

--- a/Cmdlets/Private/ConvertTo-TeamViewerRoleAssignedUserGroup.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerRoleAssignedUserGroup.ps1
@@ -7,7 +7,7 @@ function ConvertTo-TeamViewerRoleAssignedUserGroup {
 
     process {
         $Properties = @{
-            AssignedGroups = ($InputObject)
+            Assigned_UserGroups = ($InputObject)
         }
 
         $Result = New-Object -TypeName PSObject -Property $Properties

--- a/Cmdlets/Private/ConvertTo-TeamViewerSsoDomain.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerSsoDomain.ps1
@@ -13,9 +13,6 @@ function ConvertTo-TeamViewerSsoDomain {
 
         $Result = New-Object -TypeName PSObject -Property $Properties
         $Result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.SsoDomain')
-        $Result | Add-Member -MemberType ScriptMethod -Name 'ToString' -Force -Value {
-            "$($this.Name)"
-        }
 
         Write-Output $Result
     }

--- a/Cmdlets/Private/ConvertTo-TeamViewerUser.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerUser.ps1
@@ -6,7 +6,7 @@ function ConvertTo-TeamViewerUser {
 
         [Parameter()]
         [ValidateSet('All', 'Minimal')]
-        $PropertiesToLoad = 'All'
+        $PropertiesToLoad = 'Minimal'
     )
 
     process {
@@ -18,33 +18,32 @@ function ConvertTo-TeamViewerUser {
 
         if ($InputObject.userRoleId) {
             $Properties += @{
-                RoleId = $InputObject.userRoleId
+                Role_Id = $InputObject.userRoleId
             }
         }
 
         if ($PropertiesToLoad -eq 'All') {
             $Properties += @{
                 Active            = $InputObject.active
-                LastAccessDate    = $InputObject.last_access_date | ConvertTo-DateTime
-                TFAEnforcement    = $InputObject.tfa_enforcement
-                TFAEnabled        = $InputObject.tfa_enabled
-                LogSessions       = $InputObject.log_sessions
+                LastAccess_Date   = $InputObject.last_access_date | ConvertTo-DateTime
+                Log_Sessions      = $InputObject.log_sessions
                 ShowCommentWindow = $InputObject.show_comment_window
-                SSOStatus         = $InputObject.sso_status
-
+                SSO_Status        = $InputObject.sso_status
+                TFA_Enforcement   = $InputObject.tfa_enforcement
+                TFA_Enabled       = $InputObject.tfa_enabled
             }
 
             if ($InputObject.activated_license_id) {
                 $Properties += @{
-                    ActivatedLicenseId      = [guid]$InputObject.activated_license_id
-                    ActivatedLicenseName    = $InputObject.activated_license_name
-                    ActivatedSubLicenseName = $InputObject.activated_subLicense_name
+                    ActivatedLicense_Id      = [guid]$InputObject.activated_license_id
+                    ActivatedLicense_Name    = $InputObject.activated_license_name
+                    ActivatedSubLicense_Name = $InputObject.activated_subLicense_name
                 }
             }
 
             if ($InputObject.activated_meeting_license_key) {
                 $Properties += @{
-                    ActivatedMeetingLicenseId = [guid]$InputObject.activated_meeting_license_key
+                    ActivatedMeetingLicense_Id = [guid]$InputObject.activated_meeting_license_key
                 }
             }
 
@@ -56,22 +55,19 @@ function ConvertTo-TeamViewerUser {
 
             if ($InputObject.custom_quicksupport_id) {
                 $Properties += @{
-                    CustomQuickSupportId = $InputObject.custom_quicksupport_id
+                    CustomQuickSupport_Id = $InputObject.custom_quicksupport_id
                 }
             }
 
             if ($InputObject.custom_quickjoin_id) {
                 $Properties += @{
-                    CustomQuickJoinId = $InputObject.custom_quickjoin_id
+                    CustomQuickJoin_Id = $InputObject.custom_quickjoin_id
                 }
             }
         }
 
         $Result = New-Object -TypeName PSObject -Property $Properties
         $Result.PSObject.TypeNames.Insert(0, 'TeamViewerPS.User')
-        $Result | Add-Member -MemberType ScriptMethod -Name 'ToString' -Force -Value {
-            "$($this.Name) <$($this.Email)>"
-        }
 
         Write-Output $Result
     }

--- a/Cmdlets/Private/ConvertTo-TeamViewerUserGroupAssignedRole.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerUserGroupAssignedRole.ps1
@@ -1,4 +1,4 @@
-function ConvertTo-TeamViewerRoleAssignedUserGroup {
+function ConvertTo-TeamViewerUserGroupAssignedRole {
     param(
         [Parameter(ValueFromPipeline)]
         [object]

--- a/Cmdlets/Private/ConvertTo-TeamViewerUserGroupAssignedRole.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerUserGroupAssignedRole.ps1
@@ -7,7 +7,7 @@ function ConvertTo-TeamViewerRoleAssignedUserGroup {
 
     process {
         $Properties = @{
-            AssignedGroups = ($InputObject)
+            Assigned_UserGroups = ($InputObject)
         }
 
         $Result = New-Object -TypeName PSObject -Property $Properties

--- a/Cmdlets/Private/ConvertTo-TeamViewerUserGroupMember.ps1
+++ b/Cmdlets/Private/ConvertTo-TeamViewerUserGroupMember.ps1
@@ -7,8 +7,8 @@ function ConvertTo-TeamViewerUserGroupMember {
 
     process {
         $Properties = @{
-            AccountId = [int]$InputObject.accountId
-            Name      = $InputObject.name
+            Id   = [int]$InputObject.accountId
+            Name = $InputObject.name
         }
 
         $Result = New-Object -TypeName PSObject -Property $Properties

--- a/Cmdlets/Private/Resolve-TeamViewerContactId.ps1
+++ b/Cmdlets/Private/Resolve-TeamViewerContactId.ps1
@@ -11,7 +11,7 @@ function Resolve-TeamViewerContactId {
         }
         elseif ($Contact -is [string]) {
             if ($Contact -notmatch 'c[0-9]+') {
-                throw "Invalid contact identifier '$Contact'. String must be a contact ID in the form 'c123456789'."
+                throw "Invalid contact identifier '$Contact'. String must be a contact Id in the form 'c123456789'."
             }
 
             Write-Output $Contact

--- a/Cmdlets/Private/Resolve-TeamViewerDeviceId.ps1
+++ b/Cmdlets/Private/Resolve-TeamViewerDeviceId.ps1
@@ -11,7 +11,7 @@ function Resolve-TeamViewerDeviceId {
         }
         elseif ($Device -is [string]) {
             if ($Device -notmatch 'd[0-9]+') {
-                throw "Invalid device identifier '$Device'. String must be a device ID in the form 'd123456789'."
+                throw "Invalid device identifier '$Device'. String must be a device Id in the form 'd123456789'."
             }
 
             Write-Output $Device

--- a/Cmdlets/Private/Resolve-TeamViewerGroupId.ps1
+++ b/Cmdlets/Private/Resolve-TeamViewerGroupId.ps1
@@ -11,7 +11,7 @@ function Resolve-TeamViewerGroupId {
         }
         elseif ($Group -is [string]) {
             if ($Group -notmatch 'g[0-9]+') {
-                throw "Invalid group identifier '$Group'. String must be a group ID in the form 'g123456789'."
+                throw "Invalid group identifier '$Group'. String must be a group Id in the form 'g123456789'."
             }
 
             Write-Output $Group

--- a/Cmdlets/Private/Resolve-TeamViewerRoleId.ps1
+++ b/Cmdlets/Private/Resolve-TeamViewerRoleId.ps1
@@ -8,7 +8,7 @@ function Resolve-TeamViewerRoleId {
 
     process {
         if ($Role.PSObject.TypeNames -contains 'TeamViewerPS.Role') {
-            Write-Output ([string]$Role.RoleID)
+            Write-Output ([string]$Role.ID)
         }
         elseif ($Role -match '^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$') {
             Write-Output ([string]$Role)

--- a/Cmdlets/Private/Resolve-TeamViewerUserGroupMemberId.ps1
+++ b/Cmdlets/Private/Resolve-TeamViewerUserGroupMemberId.ps1
@@ -1,4 +1,4 @@
-function Resolve-TeamViewerUserGroupMemberMemberId {
+function Resolve-TeamViewerUserGroupMemberId {
     param(
         [Parameter(ValueFromPipeline = $true, Mandatory = $true)]
         [object]

--- a/Cmdlets/Private/Resolve-TeamViewerUserGroupMemberId.ps1
+++ b/Cmdlets/Private/Resolve-TeamViewerUserGroupMemberId.ps1
@@ -7,7 +7,7 @@ function Resolve-TeamViewerUserGroupMemberMemberId {
 
     process {
         if ($UserGroupMember.PSObject.TypeNames -contains 'TeamViewerPS.UserGroupMember') {
-            Write-Output $UserGroupMember.AccountId
+            Write-Output $UserGroupMember.Id
         }
         elseif ($UserGroupMember -match 'u[0-9]+') {
             Write-Output $UserGroupMember

--- a/Cmdlets/Private/Resolve-TeamViewerUserId.ps1
+++ b/Cmdlets/Private/Resolve-TeamViewerUserId.ps1
@@ -11,7 +11,7 @@ function Resolve-TeamViewerUserId {
         }
         elseif ($User -is [string]) {
             if ($User -notmatch 'u[0-9]+') {
-                throw "Invalid user identifier '$User'. String must be a user ID in the form 'u123456789'."
+                throw "Invalid user identifier '$User'. String must be a user Id in the form 'u123456789'."
             }
 
             Write-Output $User

--- a/Cmdlets/Public/Get-TeamViewerCustomModuleId.ps1
+++ b/Cmdlets/Public/Get-TeamViewerCustomModuleId.ps1
@@ -18,7 +18,7 @@ function Get-TeamViewerCustomModuleId {
                 }
             }
             catch {
-                Write-Verbose "Failed to read the custom module ID from '$TV_AssignmentFilePath': $($_.Exception.Message)"
+                Write-Verbose "Failed to read the custom module Id from '$TV_AssignmentFilePath': $($_.Exception.Message)"
 
                 return $null
             }

--- a/Cmdlets/Public/Remove-TeamViewerManager.ps1
+++ b/Cmdlets/Public/Remove-TeamViewerManager.ps1
@@ -10,7 +10,7 @@ function Remove-TeamViewerManager {
 
         [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
         [ValidateScript( {
-                if (($_.PSObject.TypeNames -contains 'TeamViewerPS.Manager') -and -not $_.GroupId -and -not $_.DeviceId) {
+                if (($_.PSObject.TypeNames -contains 'TeamViewerPS.Manager') -and -not $_.Group_Id -and -not $_.Device_Id) {
                     $PSCmdlet.ThrowTerminatingError(
                         ('Invalid manager object. Manager must be a group or device manager.' | `
                             ConvertTo-ErrorRecord -ErrorCategory InvalidArgument))
@@ -46,11 +46,11 @@ function Remove-TeamViewerManager {
                         ConvertTo-ErrorRecord -ErrorCategory InvalidArgument))
             }
 
-            if ($Manager.DeviceId) {
-                $DeviceId = $Manager.DeviceId
+            if ($Manager.Device_Id) {
+                $DeviceId = $Manager.Device_Id
             }
-            elseif ($Manager.GroupId) {
-                $GroupId = $Manager.GroupId
+            elseif ($Manager.Group_Id) {
+                $GroupId = $Manager.Group_Id
             }
         }
         elseif ($Device) {
@@ -77,12 +77,7 @@ function Remove-TeamViewerManager {
         }
 
         if ($PSCmdlet.ShouldProcess($managerId, $Process_Message)) {
-            Invoke-TeamViewerRestMethod `
-                -ApiToken $ApiToken `
-                -Uri $ResourceUri `
-                -Method Delete `
-                -WriteErrorTo $PSCmdlet | `
-                Out-Null
+            Invoke-TeamViewerRestMethod -ApiToken $ApiToken -Uri $ResourceUri -Method Delete -WriteErrorTo $PSCmdlet | Out-Null
         }
     }
 }

--- a/Cmdlets/Public/Remove-TeamViewerUserGroupMember.ps1
+++ b/Cmdlets/Public/Remove-TeamViewerUserGroupMember.ps1
@@ -17,7 +17,7 @@ function Remove-TeamViewerUserGroupMember {
 
 
         [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
-        [ValidateScript( { $_ | Resolve-TeamViewerUserGroupMemberMemberId } )]
+        [ValidateScript( { $_ | Resolve-TeamViewerUserGroupMemberId } )]
         [Alias('UserGroupMemberId')]
         [Alias('MemberId')]
         [Alias('UserId')]
@@ -48,7 +48,7 @@ function Remove-TeamViewerUserGroupMember {
         function Get-MemberId {
             switch ($UserGroupMember) {
                 { $UserGroupMember[0].PSObject.TypeNames -contains 'TeamViewerPS.UserGroupMember' } {
-                    $UserGroupMember = $UserGroupMember | Resolve-TeamViewerUserGroupMemberMemberId
+                    $UserGroupMember = $UserGroupMember | Resolve-TeamViewerUserGroupMemberId
                     return $UserGroupMember
                 }
                 default {

--- a/Cmdlets/Public/Set-TeamViewerManager.ps1
+++ b/Cmdlets/Public/Set-TeamViewerManager.ps1
@@ -10,7 +10,7 @@ function Set-TeamViewerManager {
 
         [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
         [ValidateScript( {
-                if (($_.PSObject.TypeNames -contains 'TeamViewerPS.Manager') -and -not $_.GroupId -and -not $_.DeviceId) {
+                if (($_.PSObject.TypeNames -contains 'TeamViewerPS.Manager') -and -not $_.Group_Id -and -not $_.Device_Id) {
                     $PSCmdlet.ThrowTerminatingError(
                         ('Invalid manager object. Manager must be a group or device manager.' | `
                             ConvertTo-ErrorRecord -ErrorCategory InvalidArgument))
@@ -49,7 +49,7 @@ function Set-TeamViewerManager {
     )
 
     begin {
-        # Warning suppresion doesn't seem to work.
+        # Warning suppression doesn't seem to work.
         # See https://github.com/PowerShell/PSScriptAnalyzer/issues/1472
         $null = $Property
 
@@ -60,16 +60,13 @@ function Set-TeamViewerManager {
                 $Body['permissions'] = @($Permissions)
             }
             '*ByProperties' {
-                @('permissions') | `
-                    Where-Object { $Property[$_] } | `
-                    ForEach-Object { $Body[$_] = $Property[$_] }
+                @('permissions') | Where-Object { $Property[$_] } | ForEach-Object { $Body[$_] = $Property[$_] }
             }
         }
 
         if ($Body.Count -eq 0) {
             $PSCmdlet.ThrowTerminatingError(
-                ('The given input does not change the manager.' | `
-                    ConvertTo-ErrorRecord -ErrorCategory InvalidArgument))
+                ('The given input does not change the manager.' | ConvertTo-ErrorRecord -ErrorCategory InvalidArgument))
         }
     }
     process {
@@ -79,15 +76,14 @@ function Set-TeamViewerManager {
         if ($Manager.PSObject.TypeNames -contains 'TeamViewerPS.Manager') {
             if ($Device -or $Group) {
                 $PSCmdlet.ThrowTerminatingError(
-                    ('Device or Group parameter must not be specified if a [TeamViewerPS.Manager] object is given.' | `
-                        ConvertTo-ErrorRecord -ErrorCategory InvalidArgument))
+                    ('Device or Group parameter must not be specified if a [TeamViewerPS.Manager] object is given.' | ConvertTo-ErrorRecord -ErrorCategory InvalidArgument))
             }
 
-            if ($Manager.DeviceId) {
-                $DeviceId = $Manager.DeviceId
+            if ($Manager.Device_Id) {
+                $DeviceId = $Manager.Device_Id
             }
-            elseif ($Manager.GroupId) {
-                $GroupId = $Manager.GroupId
+            elseif ($Manager.Group_Id) {
+                $GroupId = $Manager.Group_Id
             }
         }
         elseif ($Device) {
@@ -98,8 +94,7 @@ function Set-TeamViewerManager {
         }
         else {
             $PSCmdlet.ThrowTerminatingError(
-                ('Device or Group parameter must be specified if no [TeamViewerPS.Manager] object is given.' | `
-                    ConvertTo-ErrorRecord -ErrorCategory InvalidArgument))
+                ('Device or Group parameter must be specified if no [TeamViewerPS.Manager] object is given.' | ConvertTo-ErrorRecord -ErrorCategory InvalidArgument))
         }
 
         $managerId = $Manager | Resolve-TeamViewerManagerId

--- a/Docs/Help/Add-TeamViewerManagedDevice.md
+++ b/Docs/Help/Add-TeamViewerManagedDevice.md
@@ -31,8 +31,7 @@ Offline devices will apply this change when coming online again.
 PS /> Add-TeamViewerManagedDevice -Device 'c0cb303a-8a85-4e54-b657-a4757c791aef' -Group '9fd16af0-c224-4242-998e-a7138b038dbb'
 ```
 
-Adds the managed device with the given device ID to the managed group with the
-given group ID.
+Adds the managed device with the given device Id to the managed group with the given group Id.
 
 ### Example 2
 
@@ -42,8 +41,7 @@ PS /> $device = Get-TeamViewerManagedDevice -Id 'c0cb303a-8a85-4e54-b657-a4757c7
 PS /> Add-TeamViewerManagedDevice -Device $device -Group $group
 ```
 
-Adds the managed device to the managed group using device/group objects that
-have been received using other module functions.
+Adds the managed device to the managed group using device/group objects that have been received using other module functions.
 
 ## PARAMETERS
 
@@ -82,8 +80,7 @@ Accept wildcard characters: False
 ### -Device
 
 Object that can be used to identify the managed device.
-This can either be the managed device ID (as string or GUID) or a managed device
-object that has been received using other module functions.
+This can either be the managed device Id(as string or GUID) or a managed device object that has been received using other module functions.
 
 ```yaml
 Type: Object
@@ -100,8 +97,7 @@ Accept wildcard characters: False
 ### -Group
 
 Object that can be used to identify the managed group.
-This can either be the managed group ID (as string or GUID) or a managed group
-object that has been received using other module functions.
+This can either be the managed group Id(as string or GUID) or a managed group object that has been received using other module functions.
 
 ```yaml
 Type: Object

--- a/Docs/Help/Add-TeamViewerManager.md
+++ b/Docs/Help/Add-TeamViewerManager.md
@@ -15,66 +15,64 @@ Add a manager to a managed device or managed group.
 
 ### Device_ByAccountId (Default)
 
-```
+```powershell
 Add-TeamViewerManager -ApiToken <SecureString> -AccountId <String> -Device <Object> [-Permissions <String[]>]
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Group_ByAccountId
 
-```
+```powershell
 Add-TeamViewerManager -ApiToken <SecureString> -AccountId <String> -Group <Object> [-Permissions <String[]>]
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Group_ByManagerId
 
-```
+```powershell
 Add-TeamViewerManager -ApiToken <SecureString> -Manager <Object> -Group <Object> [-Permissions <String[]>]
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Device_ByManagerId
 
-```
+```powershell
 Add-TeamViewerManager -ApiToken <SecureString> -Manager <Object> -Device <Object> [-Permissions <String[]>]
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Group_ByUserObject
 
-```
+```powershell
 Add-TeamViewerManager -ApiToken <SecureString> -User <Object> -Group <Object> [-Permissions <String[]>]
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Device_ByUserObject
 
-```
+```powershell
 Add-TeamViewerManager -ApiToken <SecureString> -User <Object> -Device <Object> [-Permissions <String[]>]
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Device_ByUserGroupId
 
-```
+```powershell
 Add-TeamViewerManager -ApiToken <SecureString> -UserGroup <Object> -Device <Object> [-Permissions <String[]>]
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Group_ByUserGroupId
 
-```
+```powershell
 Add-TeamViewerManager -ApiToken <SecureString> -UserGroup <Object> -Group <Object> [-Permissions <String[]>]
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-Adds a manager to a managed device or a managed group. Managers can either be
-identified by a TeamViewer account ID or their manager ID.
-The current account (identified by the API access token) needs
-`ManagerAdministration` manager permissions on the device/group.
+Adds a manager to a managed device or a managed group. Managers can either be identified by a TeamViewer account Id or their manager Id.
+The current account (identified by the API access token) needs `ManagerAdministration` manager permissions on the device/group.
 
 ## EXAMPLES
 
@@ -84,8 +82,7 @@ The current account (identified by the API access token) needs
 PS /> Add-TeamViewerManager -Device 'c0cb303a-8a85-4e54-b657-a4757c791aef' -Manager '57e8f75e-8e6f-4450-a59d-10e02ccf5986'
 ```
 
-Add the manager with the given Manager ID to the managed device with the given
-device ID.
+Add the manager with the given Manager Id to the managed device with the given device Id.
 
 ### Example 2
 
@@ -93,8 +90,7 @@ device ID.
 PS /> Add-TeamViewerManager -Group '9fd16af0-c224-4242-998e-a7138b038dbb' -Manager '57e8f75e-8e6f-4450-a59d-10e02ccf5986'
 ```
 
-Add the manager with the given Manager ID to the managed group with the given
-group ID.
+Add the manager with the given Manager Id to the managed group with the given group Id.
 
 ### Example 3
 
@@ -102,14 +98,13 @@ group ID.
 PS /> Add-TeamViewerManager -Group '9fd16af0-c224-4242-998e-a7138b038dbb' -AccountId 1234
 ```
 
-Add the manager with the given TeamViewer account ID to the managed group with
-the given group ID.
+Add the manager with the given TeamViewer account Id to the managed group with the given group Id.
 
 ## PARAMETERS
 
 ### -AccountId
 
-TeamViewer account ID used to identify the manager to add.
+TeamViewer account Id used to identify the manager to add.
 
 ```yaml
 Type: String
@@ -158,8 +153,7 @@ Accept wildcard characters: False
 ### -Device
 
 Object that can be used to identify the managed device.
-This can either be the managed device ID (as string or GUID) or a managed device
-object that has been received using other module functions.
+This can either be the managed device Id(as string or GUID) or a managed device object that has been received using other module functions.
 
 ```yaml
 Type: Object
@@ -176,8 +170,7 @@ Accept wildcard characters: False
 ### -Group
 
 Object that can be used to identify the managed group.
-This can either be the managed group ID (as string or GUID) or a managed group
-object that has been received using other module functions.
+This can either be the managed group Id (as string or GUID) or a managed group object that has been received using other module functions.
 
 ```yaml
 Type: Object
@@ -194,8 +187,7 @@ Accept wildcard characters: False
 ### -Manager
 
 Object that can be used to identify the manager to add.
-This can either be the manager ID (as string or GUID) or a manager object that
-has been received using other module function.
+This can either be the manager Id (as string or GUID) or a manager object that has been received using other module function.
 
 ```yaml
 Type: Object
@@ -212,26 +204,18 @@ Accept wildcard characters: False
 ### -Permissions
 
 Optional permissions to give to the manager.
-By default, the manager receives an empty set of permissions, which still allows
-read-only access on the device/group data.
+By default, the manager receives an empty set of permissions, which still allows read-only access on the device/group data.
 Multiple values can be specified.
 
-`ManagerAdministration` allows the manager to change other managers on the given
-device or group.
+`ManagerAdministration` allows the manager to change other managers on the given device or group.
 
-`DeviceAdministration` (only for managed devices) allows the manager to change
-device-specific properties, e.g. the device name. Also required to add devices
-to managed groups.
+`DeviceAdministration` (only for managed devices) allows the manager to change device-specific properties, e.g. the device name. Also required to add devices to managed groups.
 
-`GroupAdministration` (only for managed groups) allows the manager to change
-group-specific properties, e.g. the group name. Also required to add managed
-devices to the group.
+`GroupAdministration` (only for managed groups) allows the manager to change group-specific properties, e.g. the group name. Also required to add managed devices to the group.
 
-`PolicyAdministration` (only for managed devices) allows the manager to change
-the policy that has been assigned to the managed device.
+`PolicyAdministration` (only for managed devices) allows the manager to change the policy that has been assigned to the managed device.
 
-`EasyAccess` allows the manager to connect to the device (or the devices of the
-group) via "EasyAccess" (without additional password).
+`EasyAccess` allows the manager to connect to the device (or the devices of the group) via "EasyAccess" (without additional password).
 
 ```yaml
 Type: String[]
@@ -247,8 +231,7 @@ Accept wildcard characters: False
 
 ### -User
 
-User object received by the `Get-TeamViewerUser` cmdlet. It can be used to
-identify the manager that should be added to the device/group.
+User object received by the `Get-TeamViewerUser` cmdlet. It can be used to identify the manager that should be added to the device/group.
 
 ```yaml
 Type: Object

--- a/Docs/Help/Add-TeamViewerSsoExclusion.md
+++ b/Docs/Help/Add-TeamViewerSsoExclusion.md
@@ -21,8 +21,7 @@ Add-TeamViewerSsoExclusion [-ApiToken] <SecureString> [-DomainId] <Object> [-Ema
 ## DESCRIPTION
 
 Add emails to the exclusion list of a TeamViewer Single Sign-On domain.
-Accounts with these email addresses do not need to login via Single
-Sign-On but use their TeamViewer account password instead.
+Accounts with these email addresses do not need to login via Single Sign-On but use their TeamViewer account password instead.
 
 ## EXAMPLES
 
@@ -32,8 +31,7 @@ Sign-On but use their TeamViewer account password instead.
 PS /> Add-TeamViewerSsoExclusion -DomainId '45e0d050-15e6-4fcb-91b2-ea4f20fe2085' -Email 'user@example.test'
 ```
 
-Adds the email address '<user@example.test>' to the exclusion list of the given
-domain.
+Adds the email address '<user@example.test>' to the exclusion list of the given domain.
 
 ## PARAMETERS
 
@@ -72,8 +70,7 @@ Accept wildcard characters: False
 ### -DomainId
 
 Object that can be used to identify the SSO domain to add exclusion entries to.
-This can either be the SSO domain ID (as string or GUID) or a SsoDomain
-object that has been received using the `Get-TeamViewerSsoDomain` function.
+This can either be the SSO domain Id (as string or GUID) or a SsoDomain object that has been received using the `Get-TeamViewerSsoDomain` function.
 
 ```yaml
 Type: Object
@@ -90,8 +87,7 @@ Accept wildcard characters: False
 ### -Email
 
 List of emails addresses to add to the exclusion list.
-The emails must be of the same email domain as the SSO domain, otherwise the
-command will fail.
+The emails must be of the same email domain as the SSO domain, otherwise the command will fail.
 
 ```yaml
 Type: String[]

--- a/Docs/Help/Add-TeamViewerSsoInclusion.md
+++ b/Docs/Help/Add-TeamViewerSsoInclusion.md
@@ -21,8 +21,7 @@ Add-TeamViewerSsoInclusion [-ApiToken] <SecureString> [-DomainId] <Object> [-Ema
 ## DESCRIPTION
 
 Add emails to the inclusion list of a TeamViewer Single Sign-On domain.
-Only accounts with these email addresses will be able to login via Single
-Sign-On.
+Only accounts with these email addresses will be able to login via Single Sign-On.
 
 ## EXAMPLES
 
@@ -32,8 +31,7 @@ Sign-On.
 PS /> Add-TeamViewerSsoInclusion -DomainId '45e0d050-15e6-4fcb-91b2-ea4f20fe2085' -Email 'user@example.test'
 ```
 
-Adds the email address '<user@example.test>' to the inclusion list of the given
-domain.
+Adds the email address '<user@example.test>' to the inclusion list of the given domain.
 
 ## PARAMETERS
 
@@ -72,8 +70,7 @@ Accept wildcard characters: False
 ### -DomainId
 
 Object that can be used to identify the SSO domain to add inclusion entries to.
-This can either be the SSO domain ID (as string or GUID) or a SsoDomain
-object that has been received using the `Get-TeamViewerSsoDomain` function.
+This can either be the SSO domain Id (as string or GUID) or a SsoDomain object that has been received using the `Get-TeamViewerSsoDomain` function.
 
 ```yaml
 Type: Object
@@ -90,8 +87,7 @@ Accept wildcard characters: False
 ### -Email
 
 List of emails addresses to add to the inclusion list.
-The emails must be of the same email domain as the SSO domain, otherwise the
-command will fail.
+The emails must be of the same email domain as the SSO domain, otherwise the command will fail.
 
 ```yaml
 Type: String[]

--- a/Docs/Help/Get-TeamViewerConnectionReport.md
+++ b/Docs/Help/Get-TeamViewerConnectionReport.md
@@ -9,8 +9,7 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
-Returns the TeamViewer session reports of the company associated with the given
-API token.
+Returns the TeamViewer session reports of the company associated with the given API token.
 
 ## SYNTAX
 
@@ -34,8 +33,7 @@ Get-TeamViewerConnectionReport -ApiToken <SecureString> [-UserName <String>] [-U
 
 ## DESCRIPTION
 
-Returns a list of TeamViewer session reports. The list can optionally be filtered
-using the given parameters.
+Returns a list of TeamViewer session reports. The list can optionally be filtered using the given parameters.
 
 ## EXAMPLES
 
@@ -69,10 +67,8 @@ List connection reports for the given session code.
 PS /> Get-TeamViewerConnectionReport -UserId u1234 -StartDate "2021-05-01 13:00"
 ```
 
-List reports for connections of the TeamViewer account with the given user ID and
-that were initiated on or after May 1st, 2021 1pm.
-If specified like this, dates/times use the timezone currently configured in
-your Powershell. For UTC, just add a `Z` at the end.
+List reports for connections of the TeamViewer account with the given user Id and that were initiated on or after May 1st, 2021 1pm.
+If specified like this, dates/times use the timezone currently configured in your Powershell. For UTC, just add a `Z` at the end.
 
 ### Example 5
 
@@ -82,8 +78,7 @@ PS /> Get-TeamViewerConnectionReport `
   -StartDate "2021-04-01" -EndDate "2021-04-02"
 ```
 
-List connection reports for devices in a group named `My Computers` and that
-have happened between April 1st and April 2nd 2021.
+List connection reports for devices in a group named `My Computers` and that have happened between April 1st and April 2nd 2021.
 This example shows the interaction with the `Get-TeamViewerGroup` cmdlet.
 
 ## PARAMETERS
@@ -123,8 +118,8 @@ Accept wildcard characters: False
 
 ### -DeviceId
 
-Filter the list of connection reports by the given device identifier. This
-needs to be the TeamViewer ID of the device.
+Filter the list of connection reports by the given device identifier.
+This needs to be the TeamViewer Id of the device.
 
 ```yaml
 Type: Int32
@@ -157,8 +152,7 @@ Accept wildcard characters: False
 ### -EndDate
 
 Sets the end for the date range of connection reports to fetch. Defaults to now.
-To be included in the results the connection is required to be ended before this
-date/time.
+To be included in the results the connection is required to be ended before this date/time.
 
 ```yaml
 Type: DateTime
@@ -174,7 +168,7 @@ Accept wildcard characters: False
 
 ### -GroupId
 
-Filter the list of connection reports by the given group ID.
+Filter the list of connection reports by the given group Id.
 
 ```yaml
 Type: Object
@@ -207,8 +201,7 @@ Accept wildcard characters: False
 
 ### -Limit
 
-Optionally limit the results to the given number. If the limit is reached the
-function stops and won't fetch more entries.
+Optionally limit the results to the given number. If the limit is reached the function stops and won't fetch more entries.
 
 ```yaml
 Type: Int32
@@ -275,8 +268,7 @@ Accept wildcard characters: False
 ### -StartDate
 
 Sets the start for the date range of connection reports to get.
-To be included in the results the connection is required to be started on or
-after this date/time.
+To be included in the results the connection is required to be started on or after this date/time.
 
 ```yaml
 Type: DateTime
@@ -309,7 +301,7 @@ Accept wildcard characters: False
 
 ### -UserId
 
-Filter the list of connection reports by the given user ID.
+Filter the list of connection reports by the given user Id.
 
 ```yaml
 Type: Object
@@ -341,8 +333,7 @@ Accept wildcard characters: False
 
 ### -WithSessionCode
 
-Filter the list of connection reports to only contain entries that have a
-session code.
+Filter the list of connection reports to only contain entries that have a session code.
 
 ```yaml
 Type: SwitchParameter
@@ -358,8 +349,7 @@ Accept wildcard characters: False
 
 ### -WithoutSessionCode
 
-Filter the list of connection reports to only contain entries that do not have a
-session code assiciated to.
+Filter the list of connection reports to only contain entries that do not have a session code associated to.
 
 ```yaml
 Type: SwitchParameter

--- a/Docs/Help/Get-TeamViewerContact.md
+++ b/Docs/Help/Get-TeamViewerContact.md
@@ -28,8 +28,7 @@ Get-TeamViewerContact -ApiToken <SecureString> [-Id <String>] [<CommonParameters
 
 ## DESCRIPTION
 
-Returns a list of contacts in the user’s Computers & Contacts list that match
-the criteria given in the parameters.
+Returns a list of contacts in the user’s Computers & Contacts list that match the criteria given in the parameters.
 
 ## EXAMPLES
 
@@ -47,7 +46,7 @@ List all contacts of the account associated to the TeamViewer API access token.
 PS /> Get-TeamViewerContact -Id 'c1234'
 ```
 
-Gets the contact entry with the given ID.
+Gets the contact entry with the given Id.
 
 ### Example 3
 
@@ -55,8 +54,7 @@ Gets the contact entry with the given ID.
 PS /> Get-TeamViewerContact -Name 'test' -FilterOnlineState 'Away'
 ```
 
-List all contacts of the account associated to the TeamViewer API access token
-that contain the string `test` in their name and are in the `Away` online state.
+List all contacts of the account associated to the TeamViewer API access token that contain the string `test` in their name and are in the `Away` online state.
 
 ## PARAMETERS
 
@@ -96,8 +94,7 @@ Accept wildcard characters: False
 ### -Group
 
 Object that can be used to identify the group.
-This can either be the group ID or a group object that has been received using
-other module functions.
+This can either be the group Id or a group object that has been received using other module functions.
 If given, the command only returns contacts that are part of that group.
 
 ```yaml
@@ -130,8 +127,7 @@ Accept wildcard characters: False
 
 ### -Name
 
-Optional filter that can be used to retrieve only those contact list entries
-that have the given string contained in their name.
+Optional filter that can be used to retrieve only those contact list entries that have the given string contained in their name.
 
 ```yaml
 Type: String

--- a/Docs/Help/Get-TeamViewerCustomModuleId.md
+++ b/Docs/Help/Get-TeamViewerCustomModuleId.md
@@ -9,7 +9,7 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
-Retrieves the currently applied TeamViewer custom module's ID.
+Retrieves the currently applied TeamViewer custom module's Id.
 
 ## SYNTAX
 
@@ -19,7 +19,7 @@ Get-TeamViewerCustomModuleId
 
 ## DESCRIPTION
 
-The command checks the TeamViewer Installation and returns the custom module ID.
+The command checks the TeamViewer Installation and returns the custom module Id.
 
 ## EXAMPLES
 

--- a/Docs/Help/Get-TeamViewerDevice.md
+++ b/Docs/Help/Get-TeamViewerDevice.md
@@ -28,8 +28,7 @@ Get-TeamViewerDevice -ApiToken <SecureString> [-Id <String>] [<CommonParameters>
 
 ## DESCRIPTION
 
-Returns a list of contacts in the user's Computers & Contacts list that match
-the criteria given in the parameters.
+Returns a list of contacts in the user's Computers & Contacts list that match the criteria given in the parameters.
 
 ## EXAMPLES
 
@@ -47,7 +46,7 @@ List all devices of the Computers & Contacts list.
 PS /> Get-TeamViewerDevice -Id 'd1234'
 ```
 
-Get the device entry with the given ID.
+Get the device entry with the given Id.
 
 ## PARAMETERS
 
@@ -87,8 +86,7 @@ Accept wildcard characters: False
 ### -Group
 
 Object that can be used to identify the group.
-This can either be the group ID or a group object that has been received using
-other module functions.
+This can either be the group Id or a group object that has been received using other module functions.
 If given, the command only returns device entries that are part of that group.
 
 ```yaml
@@ -121,7 +119,7 @@ Accept wildcard characters: False
 
 ### -TeamViewerId
 
-Optional return only the device that has the given TeamViewer Remote control ID.
+Optional return only the device that has the given TeamViewer Remote control Id.
 
 ```yaml
 Type: Int32

--- a/Docs/Help/Get-TeamViewerDeviceCustomField.md
+++ b/Docs/Help/Get-TeamViewerDeviceCustomField.md
@@ -34,7 +34,7 @@ Required: True
 
 ### -ManagedDeviceId
 
-The unique identifier of the managed device. Can be a device ID string or a TeamViewerPS.ManagedDevice object.
+The unique identifier of the managed device. Can be a device Id string or a TeamViewerPS.ManagedDevice object.
 
 ```yaml
 Type: Object
@@ -64,4 +64,4 @@ Retrieves custom field values by piping a managed device object.
 
 ### TeamViewerPS.DeviceCustomField
 
-Returns device custom field value objects containing the field key ID and value.
+Returns device custom field value objects containing the field key Id and value.

--- a/Docs/Help/Get-TeamViewerGroup.md
+++ b/Docs/Help/Get-TeamViewerGroup.md
@@ -27,8 +27,7 @@ Get-TeamViewerGroup -ApiToken <SecureString> [-Id <String>] [<CommonParameters>]
 
 ## DESCRIPTION
 
-Returns either a list of TeamViewer groups or a single TeamViewer group entry
-that are associated to the current account (API access token).
+Returns either a list of TeamViewer groups or a single TeamViewer group entry that are associated to the current account (API access token).
 
 ## EXAMPLES
 
@@ -46,7 +45,7 @@ List all TeamViewer groups of the current account.
 PS /> Get-TeamViewerGroup -Id 'g1234'
 ```
 
-Get a single TeamViewer group entry with the given ID.
+Get a single TeamViewer group entry with the given Id.
 
 ### Example 3
 
@@ -54,8 +53,7 @@ Get a single TeamViewer group entry with the given ID.
 PS /> Get-TeamViewerGroup -Name 'test'
 ```
 
-List all TeamViewer groups of the current account that have the string `test` in
-their group name.
+List all TeamViewer groups of the current account that have the string `test` in their group name.
 
 ## PARAMETERS
 
@@ -77,8 +75,7 @@ Accept wildcard characters: False
 
 ### -FilterShared
 
-Optional filter parameter to return either only groups that are shared or not
-shared.
+Optional filter parameter to return either only groups that are shared or not shared.
 
 ```yaml
 Type: String
@@ -111,8 +108,7 @@ Accept wildcard characters: False
 
 ### -Name
 
-Optional name filter parameter that can be used to only list groups that have
-the given string in their name.
+Optional name filter parameter that can be used to only list groups that have the given string in their name.
 
 ```yaml
 Type: String

--- a/Docs/Help/Get-TeamViewerId.md
+++ b/Docs/Help/Get-TeamViewerId.md
@@ -9,7 +9,7 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
-Returns the TeamViewer ID of the locally installed TeamViewer.
+Returns the TeamViewer Id of the locally installed TeamViewer.
 
 ## SYNTAX
 
@@ -19,8 +19,7 @@ Get-TeamViewerId [<CommonParameters>]
 
 ## DESCRIPTION
 
-Returns the TeamViewer ID of the locally installed TeamViewer. This ID can be
-used to connect to this machine.
+Returns the TeamViewer Id of the locally installed TeamViewer. This Id can be used to connect to this machine.
 Returns nothing if TeamViewer is not installed on this machine.
 
 ## EXAMPLES

--- a/Docs/Help/Get-TeamViewerLogFilePath.md
+++ b/Docs/Help/Get-TeamViewerLogFilePath.md
@@ -14,7 +14,7 @@ Retrieves TeamViewer log files.
 ## SYNTAX
 
 ```powershell
-Get-TeamViewerLogFilePath -OpenFile <switch>
+Get-TeamViewerLogFilePath
 ```
 
 ## DESCRIPTION
@@ -31,31 +31,7 @@ PS /> Get-TeamViewerLogFilePath
 
 Returns the paths for log files.
 
-### Example 2
-
-```powershell
-PS /> Get-TeamViewerLogFilePath -OpenFile
-```
-
-Provides a prompt with choice to open the located files.
-
 ## PARAMETERS
-
-### -OpenFile
-
-Switch to open a log file.
-
-```yaml
-Type: switch
-Parameter Sets: (All)
-Aliases: None
-
-Required: False
-Position: 0
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
 
 ### CommonParameters
 

--- a/Docs/Help/Get-TeamViewerManagedDevice.md
+++ b/Docs/Help/Get-TeamViewerManagedDevice.md
@@ -33,9 +33,8 @@ Get-TeamViewerManagedDevice -ApiToken <SecureString> -Group <Object> [-Pending] 
 
 ## DESCRIPTION
 
-Retrieves managed devices of the manager that is associated with the API access
-token. This can either be devices where this manager was added directly or
-optionally devices of a managed group.
+Retrieves managed devices of the manager that is associated with the API access token.
+This can either be devices where this manager was added directly or optionally devices of a managed group.
 
 ## EXAMPLES
 
@@ -55,8 +54,7 @@ List all directly managed devices of this manager.
 PS /> Get-TeamViewerManagedDevice -Group '9fd16af0-c224-4242-998e-a7138b038dbb'
 ```
 
-List all managed devices of the given group. This manager needs to be part of
-the group.
+List all managed devices of the given group. This manager needs to be part of the group.
 
 ### Example 3
 
@@ -65,7 +63,7 @@ the group.
 PS /> Get-TeamViewerManagedDevice -Id 'c0cb303a-8a85-4e54-b657-a4757c791aef'
 ```
 
-Retrieve a single managed device entry for the device with the given ID.
+Retrieve a single managed device entry for the device with the given Id.
 
 ### Example 4
 
@@ -96,9 +94,7 @@ Accept wildcard characters: False
 ### -Group
 
 Object that can be used to identify a managed group.
-This can either be the managed group ID (as string or GUID) or a managed group
-object that has been received using other module functions.
-
+This can either be the managed group Id (as string or GUID) or a managed group object that has been received using other module functions.
 If given, the command returns managed devices of that group.
 
 ```yaml
@@ -115,8 +111,7 @@ Accept wildcard characters: False
 
 ### -Id
 
-Optional managed device ID. If given, the command retrieves a single managed
-device entry with this device ID.
+Optional managed device Id. If given, the command retrieves a single managed device entry with this device Id.
 
 ```yaml
 Type: Guid
@@ -132,11 +127,8 @@ Accept wildcard characters: False
 
 ### -Pending
 
-If given, the command will retrieve the list of pending device entries for a
-given managed group. Such pending devices will either join or leave the group
-as soon as they apply the outstanding changes (e.g. when the devices come
-online again).
-
+If given, the command will retrieve the list of pending device entries for a given managed group.
+Such pending devices will either join or leave the group as soon as they apply the outstanding changes (e.g. when the devices come online again).
 The pending operation is indicated by the `PendingOperation` object member. 
 
 ```yaml

--- a/Docs/Help/Get-TeamViewerManagedGroup.md
+++ b/Docs/Help/Get-TeamViewerManagedGroup.md
@@ -33,8 +33,7 @@ Get-TeamViewerManagedGroup -ApiToken <SecureString> [-Device <Object>] [<CommonP
 
 ## DESCRIPTION
 
-Retrieves managed groups of the manager that is associated with the API access
-token.
+Retrieves managed groups of the manager that is associated with the API access token.
 
 ## EXAMPLES
 
@@ -52,7 +51,7 @@ List all managed groups of this manager.
 PS /> Get-TeamViewerManagedGroup -Id '9fd16af0-c224-4242-998e-a7138b038dbb'
 ```
 
-Retrieve a single managed group entry for the group with the given ID.
+Retrieve a single managed group entry for the group with the given Id.
 
 ## PARAMETERS
 
@@ -75,11 +74,8 @@ Accept wildcard characters: False
 ### -Device
 
 Object that can be used to identify a managed device.
-This can either be the managed device ID (as string or GUID) or a managed device
-object that has been received using other module functions.
-
-If given, this command returns the list of managed groups that the device is
-part of.
+This can either be the managed device Id (as string or GUID) or a managed device object that has been received using other module functions.
+If given, this command returns the list of managed groups that the device is part of.
 
 ```yaml
 Type: Object
@@ -95,8 +91,7 @@ Accept wildcard characters: False
 
 ### -Id
 
-Optional managed group ID. If given, the command retrieves a single managed
-group entry with this ID.
+Optional managed group Id. If given, the command retrieves a single managed group entry with this Id.
 
 ```yaml
 Type: Guid

--- a/Docs/Help/Get-TeamViewerManagementId.md
+++ b/Docs/Help/Get-TeamViewerManagementId.md
@@ -9,7 +9,7 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
-Returns the TeamViewer Management ID of the locally installed TeamViewer.
+Returns the TeamViewer Management Id of the locally installed TeamViewer.
 
 ## SYNTAX
 
@@ -19,13 +19,9 @@ Get-TeamViewerManagementId
 
 ## DESCRIPTION
 
-Returns the TeamViewer Management ID of the locally installed TeamViewer if the
-device is managed in the Managed Groups system.
-Returns nothing if either TeamViewer is not installed or the device is not a
-managed device in the Managed Groups system.
-For example, the management ID can be used as `DeviceId` for the
-`Get-TeamViewerManagedDevice` command (and all other Managed Device/Group
-related commands). 
+Returns the TeamViewer Management Id of the locally installed TeamViewer if the device is managed in the managed groups system.
+Returns nothing if either TeamViewer is not installed or the device is not a managed device in the managed groups system.
+For example, the management Id can be used as `DeviceId` for the `Get-TeamViewerManagedDevice` command (and all other managed device / group related commands). 
 
 ## EXAMPLES
 

--- a/Docs/Help/Get-TeamViewerManager.md
+++ b/Docs/Help/Get-TeamViewerManager.md
@@ -37,7 +37,7 @@ Retrieves the list of managers of a managed device or a managed group.
 PS /> Get-TeamViewerManager -Device 'c0cb303a-8a85-4e54-b657-a4757c791aef'
 ```
 
-List the managers of the managed device with the given ID.
+List the managers of the managed device with the given Id.
 
 ## PARAMETERS
 
@@ -60,8 +60,7 @@ Accept wildcard characters: False
 ### -Device
 
 Object that can be used to identify the managed device.
-This can either be the managed device ID (as string or GUID) or a managed device
-object that has been received using other module functions.
+This can either be the managed device Id (as string or GUID) or a managed device object that has been received using other module functions.
 
 ```yaml
 Type: Object
@@ -78,8 +77,7 @@ Accept wildcard characters: False
 ### -Group
 
 Object that can be used to identify the managed group.
-This can either be the managed group ID (as string or GUID) or a managed group
-object that has been received using other module functions.
+This can either be the managed group Id (as string or GUID) or a managed group object that has been received using other module functions.
 
 ```yaml
 Type: Object

--- a/Docs/Help/Get-TeamViewerPolicy.md
+++ b/Docs/Help/Get-TeamViewerPolicy.md
@@ -45,7 +45,7 @@ List all policies of this account.
 PS /> Get-TeamViewerPolicy -Id '730ee15a-1ea4-4d80-9cfe-5a01709d0a2f'
 ```
 
-Retrieve a single policy entry with the given ID.
+Retrieve a single policy entry with the given Id.
 
 ## PARAMETERS
 
@@ -67,7 +67,7 @@ Accept wildcard characters: False
 
 ### -Id
 
-Optional policy ID to retrieve a single policy entry.
+Optional policy Id to retrieve a single policy entry.
 
 ```yaml
 Type: Guid

--- a/Docs/Help/Get-TeamViewerPredefinedRole.md
+++ b/Docs/Help/Get-TeamViewerPredefinedRole.md
@@ -29,12 +29,12 @@ Retrieves the Predefined role among the existing roles in the TeamViewer company
 PS /> Get-TeamViewerPredefinedRole
 ```
 
-Retrieves the Predefined Role ID.
+Retrieves the Predefined Role Id.
 
 ### Example 2
 
 ```powershell
-PS /> forEach-Object { Get-TeamViewerRole | Where-Object { $_.RoleID -eq (Get-TeamViewerPredefinedRole).PredefinedRoleID } }
+PS /> forEach-Object { Get-TeamViewerRole | Where-Object { $_.RoleId -eq (Get-TeamViewerPredefinedRole).Role_Id } }
 ```
 
 Retrieves the complete information about the predefined role.

--- a/Docs/Help/Get-TeamViewerRoleByUser.md
+++ b/Docs/Help/Get-TeamViewerRoleByUser.md
@@ -29,7 +29,7 @@ Lists the assigned roles of a user in the TeamViewer company associated with the
 PS /> Get-TeamViewerRoleByUser -UserId "u123456777"
 ```
 
-Lists the assigned roles of the user with the ID u123456777.
+Lists the assigned roles of the user with the Id u123456777.
 
 ## PARAMETERS
 

--- a/Docs/Help/Get-TeamViewerRoleByUserGroup.md
+++ b/Docs/Help/Get-TeamViewerRoleByUserGroup.md
@@ -29,7 +29,7 @@ Lists the assigned role of a user group in the TeamViewer company associated wit
 PS /> Get-TeamViewerRoleByUserGroup -GroupId "12345"
 ```
 
-Lists the assigned role of the user group with the ID 12345.
+Lists the assigned role of the user group with the Id 12345.
 
 ## PARAMETERS
 

--- a/Docs/Help/Get-TeamViewerSsoExclusion.md
+++ b/Docs/Help/Get-TeamViewerSsoExclusion.md
@@ -20,8 +20,7 @@ Get-TeamViewerSsoExclusion [-ApiToken] <SecureString> [-DomainId] <Object> [<Com
 ## DESCRIPTION
 
 Get the list of excluded email addresses for a given TeamViewer SSO domain.
-These email addresses are excluded from logging in via Single Sign-On and
-instead must login using their TeamViewer account password.
+These email addresses are excluded from logging in via Single Sign-On and instead must login using their TeamViewer account password.
 
 ## EXAMPLES
 
@@ -52,8 +51,7 @@ Accept wildcard characters: False
 ### -DomainId
 
 Object that can be used to identify the SSO domain to get exclusion entries for.
-This can either be the SSO domain ID (as string or GUID) or a SsoDomain
-object that has been received using the `Get-TeamViewerSsoDomain` function.
+This can either be the SSO domain Id (as string or GUID) or a SsoDomain object that has been received using the `Get-TeamViewerSsoDomain` function.
 
 ```yaml
 Type: Object

--- a/Docs/Help/Get-TeamViewerSsoInclusion.md
+++ b/Docs/Help/Get-TeamViewerSsoInclusion.md
@@ -20,8 +20,7 @@ Get-TeamViewerSsoInclusion [-ApiToken] <SecureString> [-DomainId] <Object> [<Com
 ## DESCRIPTION
 
 Get the list of included email addresses for a given TeamViewer SSO domain.
-These email addresses are included from logging in via Single Sign-On and
-do not have to login using their TeamViewer account password.
+These email addresses are included from logging in via Single Sign-On and do not have to login using their TeamViewer account password.
 
 ## EXAMPLES
 
@@ -52,8 +51,7 @@ Accept wildcard characters: False
 ### -DomainId
 
 Object that can be used to identify the SSO domain to get inclusion entries for.
-This can either be the SSO domain ID (as string or GUID) or a SsoDomain
-object that has been received using the `Get-TeamViewerSsoDomain` function.
+This can either be the SSO domain Id (as string or GUID) or a SsoDomain object that has been received using the `Get-TeamViewerSsoDomain` function.
 
 ```yaml
 Type: Object

--- a/Docs/Help/Get-TeamViewerUser.md
+++ b/Docs/Help/Get-TeamViewerUser.md
@@ -47,7 +47,7 @@ List all users.
 PS /> Get-TeamViewerUser -Id 'u1234'
 ```
 
-Retrieve a single user entry with the given ID.
+Retrieve a single user entry with the given Id.
 
 ### Example 3
 
@@ -110,7 +110,7 @@ Accept wildcard characters: False
 
 ### -Id
 
-User ID to return only a single user entry with that ID.
+User Id to return only a single user entry with that Id.
 
 ```yaml
 Type: String

--- a/Docs/Help/Move-TeamViewerManagedDevice.md
+++ b/Docs/Help/Move-TeamViewerManagedDevice.md
@@ -32,8 +32,7 @@ Offline devices will apply this change when coming online again.
 PS /> Move-TeamViewerManagedDevice -Device 'c0cb303a-8a85-4e54-b657-a4757c791aef' -SourceGroup '9fd16af0-c224-4242-998e-a7138b038dbb' -TargetGroup '6084ffb1-c2d7-45e8-b6ab-5322ff761a30'
 ```
 
-Moves the managed device with the given device ID from the managed group with the
-given group ID to another managed group with the given group ID.
+Moves the managed device with the given device Id from the managed group with the given group Id to another managed group with the given group Id.
 
 ## PARAMETERS
 
@@ -71,7 +70,7 @@ Accept wildcard characters: False
 
 ### -Device
 
-A string representing the management ID of the device.
+A string representing the management Id of the device.
 
 ```yaml
 Type: Object
@@ -87,7 +86,7 @@ Accept wildcard characters: False
 
 ### -SourceGroup
 
-A string representing the group ID of the source group.
+A string representing the group Id of the source group.
 
 ```yaml
 Type: Object
@@ -103,7 +102,7 @@ Accept wildcard characters: False
 
 ### -TargetGroup
 
-A string representing the group ID of the target group.
+A string representing the group Id of the target group.
 
 ```yaml
 Type: Object

--- a/Docs/Help/New-TeamViewerContact.md
+++ b/Docs/Help/New-TeamViewerContact.md
@@ -20,8 +20,7 @@ New-TeamViewerContact [-ApiToken] <SecureString> [-Email] <String> [-Group] <Obj
 
 ## DESCRIPTION
 
-Adds a new contact to the Computers & Contacts list of the account that is
-associated to the TeamViewer API access token. 
+Adds a new contact to the Computers & Contacts list of the account that is associated to the TeamViewer API access token. 
 
 ## EXAMPLES
 
@@ -31,8 +30,7 @@ associated to the TeamViewer API access token.
 PS /> New-TeamViewerContact -Email 'test@example.test' -Group 'g1234'
 ```
 
-Add the account with the given email address to the Computers & Contacts list
-into the group with the given group ID.
+Add the account with the given email address to the Computers & Contacts list into the group with the given group Id.
 
 ### Example 2
 
@@ -40,8 +38,7 @@ into the group with the given group ID.
 PS /> New-TeamViewerContact -Email 'another@example.test' -Group 'g1234' -Invite
 ```
 
-Add a new entry to the Computers & Contacts list and send an invitation to the
-given email address if no such user exists yet.
+Add a new entry to the Computers & Contacts list and send an invitation to the given email address if no such user exists yet.
 
 ## PARAMETERS
 
@@ -96,8 +93,7 @@ Accept wildcard characters: False
 ### -Group
 
 Object that can be used to identify the group.
-This can either be the group ID or a group object that has been received using
-other module functions.
+This can either be the group Id or a group object that has been received using other module functions.
 
 ```yaml
 Type: Object

--- a/Docs/Help/New-TeamViewerDevice.md
+++ b/Docs/Help/New-TeamViewerDevice.md
@@ -20,8 +20,7 @@ New-TeamViewerDevice [-ApiToken] <SecureString> [-TeamViewerId] <Int32> [-Group]
 
 ## DESCRIPTION
 
-Adds a new device entry to the Computers & Contacts list of the account that is
-associated to the TeamViewer API access token. 
+Adds a new device entry to the Computers & Contacts list of the account that is associated to the TeamViewer API access token. 
 
 ## EXAMPLES
 
@@ -31,8 +30,7 @@ associated to the TeamViewer API access token.
 PS /> New-TeamViewerDevice -TeamViewerId 12345678 -Group 'g1234'
 ```
 
-Adds the device with the given TeamViewer ID to the Computers & Contacts list
-into the group with the given group ID.
+Adds the device with the given TeamViewer Id to the Computers & Contacts list into the group with the given group Id.
 
 ## PARAMETERS
 
@@ -87,8 +85,7 @@ Accept wildcard characters: False
 ### -Group
 
 Object that can be used to identify the group.
-This can either be the group ID or a group object that has been received using
-other module functions.
+This can either be the group Id or a group object that has been received using other module functions.
 
 ```yaml
 Type: Object
@@ -120,8 +117,7 @@ Accept wildcard characters: False
 
 ### -Password
 
-Optional password that will be used when connecting to the device with the
-TeamViewer desktop client.
+Optional password that will be used when connecting to the device with the TeamViewer desktop client.
 
 ```yaml
 Type: SecureString
@@ -137,7 +133,7 @@ Accept wildcard characters: False
 
 ### -TeamViewerId
 
-The TeamViewer remote control ID of the device to be added.
+The TeamViewer remote control Id of the device to be added.
 
 ```yaml
 Type: Int32

--- a/Docs/Help/New-TeamViewerGroup.md
+++ b/Docs/Help/New-TeamViewerGroup.md
@@ -85,8 +85,7 @@ Accept wildcard characters: False
 ### -Policy
 
 Optional object that can be used to identify the policy.
-This can either be the policy ID or a policy object that has been received using
-other module functions.
+This can either be the policy Id or a policy object that has been received using other module functions.
 If given, the policy will be assigned to the group.
 
 ```yaml

--- a/Docs/Help/New-TeamViewerUser.md
+++ b/Docs/Help/New-TeamViewerUser.md
@@ -241,7 +241,7 @@ Accept wildcard characters: False
 
 ### -CustomQuickSupportId
 
-Defines the ID of a custom QuickSupport module assigned to the user.
+Defines the Id of a custom QuickSupport module assigned to the user.
 
 ```yaml
 Type: String
@@ -257,7 +257,7 @@ Accept wildcard characters: False
 
 ### -CustomQuickJoinId
 
-Specifies the ID of a custom QuickJoin module assigned to the user.
+Specifies the Id of a custom QuickJoin module assigned to the user.
 
 ```yaml
 Type: String
@@ -302,6 +302,7 @@ Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
+
 ### -SubscribeNewsletter
 
 Enables (`$true`) or disables (`$false`) the newsletter.

--- a/Docs/Help/Publish-TeamViewerGroup.md
+++ b/Docs/Help/Publish-TeamViewerGroup.md
@@ -21,8 +21,7 @@ Publish-TeamViewerGroup [-ApiToken] <SecureString> [-Group] <Object> [-User] <Ob
 ## DESCRIPTION
 
 Shares a Computers & Contacts list group with the given users.
-It will not change the share-state of other users, but it is possible to
-overwrite the permissions of existing shares.
+It will not change the share-state of other users, but it is possible to overwrite the permissions of existing shares.
 
 ## EXAMPLES
 
@@ -71,8 +70,7 @@ Accept wildcard characters: False
 ### -Group
 
 Object that can be used to identify the group.
-This can either be the group ID or a group object that has been received using
-other module functions.
+This can either be the group Id or a group object that has been received using other module functions.
 
 ```yaml
 Type: Object
@@ -106,8 +104,7 @@ Accept wildcard characters: False
 ### -User
 
 Object that can be used to identify the user.
-This can either be the user ID or a user object that has been received using
-other module functions.
+This can either be the user Id or a user object that has been received using other module functions.
 
 ```yaml
 Type: Object[]

--- a/Docs/Help/Remove-TeamViewerContact.md
+++ b/Docs/Help/Remove-TeamViewerContact.md
@@ -20,8 +20,7 @@ Remove-TeamViewerContact [-ApiToken] <SecureString> [-Contact] <Object> [-WhatIf
 
 ## DESCRIPTION
 
-Deletes a contact from the Computers & Contacts list of the account associated
-to the API access token.
+Deletes a contact from the Computers & Contacts list of the account associated to the API access token.
 
 ## EXAMPLES
 
@@ -68,8 +67,7 @@ Accept wildcard characters: False
 ### -Contact
 
 Object that can be used to identify the contact.
-This can either be the contact ID or a contact object that has been received
-using other module functions.
+This can either be the contact Id or a contact object that has been received using other module functions.
 
 ```yaml
 Type: Object

--- a/Docs/Help/Remove-TeamViewerDevice.md
+++ b/Docs/Help/Remove-TeamViewerDevice.md
@@ -19,8 +19,7 @@ Remove-TeamViewerDevice [-ApiToken] <SecureString> [-Device] <Object> [-WhatIf] 
 
 ## DESCRIPTION
 
-Deletes a device from the Computers & Contacts list of the account associated to
-the API access token.
+Deletes a device from the Computers & Contacts list of the account associated to the API access token.
 
 ## EXAMPLES
 
@@ -67,8 +66,7 @@ Accept wildcard characters: False
 ### -Device
 
 Object that can be used to identify the device entry.
-This can either be the device ID or a device object that has been received
-using other module functions.
+This can either be the device Id or a device object that has been received using other module functions.
 
 ```yaml
 Type: Object

--- a/Docs/Help/Remove-TeamViewerDeviceCustomField.md
+++ b/Docs/Help/Remove-TeamViewerDeviceCustomField.md
@@ -34,7 +34,7 @@ Required: True
 
 ### -ManagedDeviceId
 
-The unique identifier of the managed device. Can be a device ID string or a TeamViewerPS.ManagedDevice object.
+The unique identifier of the managed device. Can be a device Id string or a TeamViewerPS.ManagedDevice object.
 
 ```yaml
 Type: Object

--- a/Docs/Help/Remove-TeamViewerGroup.md
+++ b/Docs/Help/Remove-TeamViewerGroup.md
@@ -19,8 +19,7 @@ Remove-TeamViewerGroup [-ApiToken] <SecureString> [-Group] <Object> [-WhatIf] [-
 
 ## DESCRIPTION
 
-Deletes an existing group from the Computers & Contacts list. If the group is
-not owned, but only shared with the current user's account it will just be
+Deletes an existing group from the Computers & Contacts list. If the group is not owned, but only shared with the current user's account it will just be
 unshared.
 
 ## EXAMPLES
@@ -68,8 +67,7 @@ Accept wildcard characters: False
 ### -Group
 
 Object that can be used to identify the group.
-This can either be the group ID or a group object that has been received using
-other module functions.
+This can either be the group Id or a group object that has been received using other module functions.
 
 ```yaml
 Type: Object

--- a/Docs/Help/Remove-TeamViewerManagedDevice.md
+++ b/Docs/Help/Remove-TeamViewerManagedDevice.md
@@ -20,10 +20,8 @@ Remove-TeamViewerManagedDevice [-ApiToken] <SecureString> [-Device] <Object> [[-
 
 ## DESCRIPTION
 
-Removes a managed device from a managed group. The device remains in the
-pending status "leave" until it gets online and actually leaves the managed
-group. The current account needs `DeviceAdministration` manager permissions on
-the device. 
+Removes a managed device from a managed group. The device remains in the pending status "leave" until it gets online and actually leaves the managed group.
+The current account needs `DeviceAdministration` manager permissions on the device. 
 
 ## EXAMPLES
 
@@ -70,8 +68,7 @@ Accept wildcard characters: False
 ### -Device
 
 Object that can be used to identify the managed device.
-This can either be the managed device ID (as string or GUID) or a managed device
-object that has been received using other module functions.
+This can either be the managed device Id (as string or GUID) or a managed device object that has been received using other module functions.
 
 ```yaml
 Type: Object
@@ -88,8 +85,7 @@ Accept wildcard characters: False
 ### -Group
 
 Object that can be used to identify the managed group.
-This can either be the managed group ID (as string or GUID) or a managed group
-object that has been received using other module functions.
+This can either be the managed group Id (as string or GUID) or a managed group object that has been received using other module functions.
 
 ```yaml
 Type: Object

--- a/Docs/Help/Remove-TeamViewerManagedDeviceManagement.md
+++ b/Docs/Help/Remove-TeamViewerManagedDeviceManagement.md
@@ -69,8 +69,7 @@ Accept wildcard characters: False
 ### -Device
 
 Object that can be used to identify the managed device.
-This can either be the managed device ID (as string or GUID) or a managed device
-object that has been received using other module functions.
+This can either be the managed device Id (as string or GUID) or a managed device object that has been received using other module functions.
 
 ```yaml
 Type: Object

--- a/Docs/Help/Remove-TeamViewerManagedGroup.md
+++ b/Docs/Help/Remove-TeamViewerManagedGroup.md
@@ -21,8 +21,7 @@ Remove-TeamViewerManagedGroup [-ApiToken] <SecureString> [-Group] <Object> [-Wha
 ## DESCRIPTION
 
 Marks a managed group as deleted. It will immediately disappear from the list of
-managed groups of all associated managers. Devices in the group will see the
-deletion marker and remove themselves from the group as soon as they get online.
+managed groups of all associated managers. Devices in the group will see the deletion marker and remove themselves from the group as soon as they get online.
 
 ## EXAMPLES
 
@@ -69,8 +68,7 @@ Accept wildcard characters: False
 ### -Group
 
 Object that can be used to identify the managed group.
-This can either be the managed group ID (as string or GUID) or a managed group
-object that has been received using other module functions.
+This can either be the managed group Id (as string or GUID) or a managed group object that has been received using other module functions.
 
 ```yaml
 Type: Object

--- a/Docs/Help/Remove-TeamViewerManager.md
+++ b/Docs/Help/Remove-TeamViewerManager.md
@@ -31,10 +31,7 @@ Remove-TeamViewerManager -ApiToken <SecureString> -Manager <Object> [-Group <Obj
 
 Removes a manager from a managed group or a managed device.
 The current manager requires `ManagerAdministration` manager permissions.
-
-It is not possible to remove the last manager with `ManagerAdministration` from
-a managed group or managed device. At least one manager must remain with that
-permission.
+It is not possible to remove the last manager with `ManagerAdministration` from a managed group or managed device. At least one manager must remain with that permission.
 
 ## EXAMPLES
 
@@ -91,8 +88,7 @@ Accept wildcard characters: False
 ### -Device
 
 Object that can be used to identify the managed device.
-This can either be the managed device ID (as string or GUID) or a managed device
-object that has been received using other module functions.
+This can either be the managed device Id (as string or GUID) or a managed device object that has been received using other module functions.
 
 ```yaml
 Type: Object
@@ -109,8 +105,7 @@ Accept wildcard characters: False
 ### -Group
 
 Object that can be used to identify the managed group.
-This can either be the managed group ID (as string or GUID) or a managed group
-object that has been received using other module functions.
+This can either be the managed group Id (as string or GUID) or a managed group object that has been received using other module functions.
 
 ```yaml
 Type: Object
@@ -127,8 +122,7 @@ Accept wildcard characters: False
 ### -Manager
 
 Object that can be used to identify the manager.
-This can either be the manager ID (as string or GUID) or a manager object that
-has been received using other module functions.
+This can either be the manager Id (as string or GUID) or a manager object that has been received using other module functions.
 
 ```yaml
 Type: Object

--- a/Docs/Help/Remove-TeamViewerPolicy.md
+++ b/Docs/Help/Remove-TeamViewerPolicy.md
@@ -26,7 +26,7 @@ Delete the specified TeamViewer policy.
 ### Example 1
 
 ```powershell
-PS /> Remove-TeamViewerPolicy -Policy '730ee15a-1ea4-4d80-9cfe-5a01709d0a2f'
+Remove-TeamViewerPolicy -Policy '730ee15a-1ea4-4d80-9cfe-5a01709d0a2f'
 ```
 
 ## PARAMETERS
@@ -66,8 +66,7 @@ Accept wildcard characters: False
 ### -Policy
 
 Object that can be used to identify the policy.
-This can either be the policy ID (as string or GUID) or a policy object that has
-been received using other module functions.
+This can either be the policy Id (as string or GUID) or a policy object that has been received using other module functions.
 
 ```yaml
 Type: Object

--- a/Docs/Help/Remove-TeamViewerPolicyFromManagedGroup.md
+++ b/Docs/Help/Remove-TeamViewerPolicyFromManagedGroup.md
@@ -85,8 +85,7 @@ Accept wildcard characters: False
 ### -Group
 
 Object that can be used to identify the managed group.
-This can either be the managed group ID (as string or GUID) or a managed group
-object that has been received using other module functions.
+This can either be the managed group Id (as string or GUID) or a managed group object that has been received using other module functions.
 
 ```yaml
 Type: Object

--- a/Docs/Help/Remove-TeamViewerSsoExclusion.md
+++ b/Docs/Help/Remove-TeamViewerSsoExclusion.md
@@ -21,8 +21,7 @@ Remove-TeamViewerSsoExclusion [-ApiToken] <SecureString> [-DomainId] <Object> [-
 ## DESCRIPTION
 
 Remove emails from the exclusion list of a TeamViewer Single Sign-On domain.
-Accounts with these email addresses do not need to login via Single
-Sign-On but use their TeamViewer account password instead.
+Accounts with these email addresses do not need to login via Single Sign-On but use their TeamViewer account password instead.
 
 ## EXAMPLES
 
@@ -32,8 +31,7 @@ Sign-On but use their TeamViewer account password instead.
 PS /> Remove-TeamViewerSsoExclusion -DomainId '45e0d050-15e6-4fcb-91b2-ea4f20fe2085' -Email 'user@example.test'
 ```
 
-Removes the email address '<user@example.test>' from the exclusion list of the
-given domain.
+Removes the email address '<user@example.test>' from the exclusion list of the given domain.
 
 ## PARAMETERS
 
@@ -55,10 +53,8 @@ Accept wildcard characters: False
 
 ### -DomainId
 
-Object that can be used to identify the SSO domain to remove exclusion entries
-from.
-This can either be the SSO domain ID (as string or GUID) or a SsoDomain
-object that has been received using the `Get-TeamViewerSsoDomain` function.
+Object that can be used to identify the SSO domain to remove exclusion entries from.
+This can either be the SSO domain Id (as string or GUID) or a SsoDomain object that has been received using the `Get-TeamViewerSsoDomain` function.
 
 ```yaml
 Type: Object

--- a/Docs/Help/Remove-TeamViewerSsoInclusion.md
+++ b/Docs/Help/Remove-TeamViewerSsoInclusion.md
@@ -21,8 +21,7 @@ Remove-TeamViewerSsoInclusion [-ApiToken] <SecureString> [-DomainId] <Object> [-
 ## DESCRIPTION
 
 Remove emails from the inclusion list of a TeamViewer Single Sign-On domain.
-Accounts with these email addresses do need to login via Single
-Sign-On and do not have to use their TeamViewer account password.
+Accounts with these email addresses do need to login via Single Sign-On and do not have to use their TeamViewer account password.
 
 ## EXAMPLES
 
@@ -32,8 +31,7 @@ Sign-On and do not have to use their TeamViewer account password.
 PS /> Remove-TeamViewerSsoInclusion -DomainId '45e0d050-15e6-4fcb-91b2-ea4f20fe2085' -Email 'user@example.test'
 ```
 
-Removes the email address '<user@example.test>' from the Inclusion list of the
-given domain.
+Removes the email address '<user@example.test>' from the Inclusion list of the given domain.
 
 ## PARAMETERS
 
@@ -55,10 +53,8 @@ Accept wildcard characters: False
 
 ### -DomainId
 
-Object that can be used to identify the SSO domain to remove inclusion entries
-from.
-This can either be the SSO domain ID (as string or GUID) or a SsoDomain
-object that has been received using the `Get-TeamViewerSsoDomain` function.
+Object that can be used to identify the SSO domain to remove inclusion entries from.
+This can either be the SSO domain Id (as string or GUID) or a SsoDomain object that has been received using the `Get-TeamViewerSsoDomain` function.
 
 ```yaml
 Type: Object

--- a/Docs/Help/Remove-TeamViewerUser.md
+++ b/Docs/Help/Remove-TeamViewerUser.md
@@ -84,7 +84,7 @@ Accept wildcard characters: False
 ### -User
 
 Object that can be used to identify the user.
-This can either be the user ID or a user object that has been received using other module functions
+This can either be the user Id or a user object that has been received using other module functions.
 
 ```yaml
 Type: Object

--- a/Docs/Help/Remove-TeamViewerUserTFA.md
+++ b/Docs/Help/Remove-TeamViewerUserTFA.md
@@ -20,7 +20,7 @@ Remove-TeamViewerUser [-ApiToken] <SecureString> [-User] <Object> [-Permanent] [
 
 ## DESCRIPTION
 
-Removes a users two-factor authentification (TFA) from the TeamViewer account.
+Removes a users two-factor authentication (TFA) from the TeamViewer account.
 
 ## EXAMPLES
 
@@ -51,7 +51,7 @@ Accept wildcard characters: False
 ### -User
 
 Object that can be used to identify the user.
-This can either be the user ID or a user object that has been received using other module functions
+This can either be the user Id or a user object that has been received using other module functions.
 
 ```yaml
 Type: Object
@@ -64,6 +64,7 @@ Default value: None
 Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
+
 ### -Confirm
 
 Prompts you for confirmation before running the cmdlet.

--- a/Docs/Help/Set-TeamViewerDevice.md
+++ b/Docs/Help/Set-TeamViewerDevice.md
@@ -117,7 +117,7 @@ Accept wildcard characters: False
 ### -Device
 
 Object that can be used to identify the device entry.
-This can either be the device ID or a device object that has been received
+This can either be the device Id or a device object that has been received
 using other module functions.
 
 ```yaml
@@ -135,7 +135,7 @@ Accept wildcard characters: False
 ### -Group
 
 Object that can be used to identify the group.
-This can either be the group ID or a group object that has been received using
+This can either be the group Id or a group object that has been received using
 other module functions.
 
 Cannot be used in conjunction with the `-Policy` parameter.
@@ -188,7 +188,7 @@ Accept wildcard characters: False
 ### -Policy
 
 Object that can be used to identify the policy.
-This can either be the policy ID (as string or GUID) or a policy object that has
+This can either be the policy Id (as string or GUID) or a policy object that has
 been received using other module functions.
 
 Cannot be used in conjunction with the `-Group` parameter.

--- a/Docs/Help/Set-TeamViewerDeviceCustomField.md
+++ b/Docs/Help/Set-TeamViewerDeviceCustomField.md
@@ -34,7 +34,7 @@ Required: True
 
 ### -ManagedDeviceId
 
-The unique identifier of the managed device. Can be a device ID string or a TeamViewerPS.ManagedDevice object.
+The unique identifier of the managed device. Can be a device Id string or a TeamViewerPS.ManagedDevice object.
 
 ```yaml
 Type: Object

--- a/Docs/Help/Set-TeamViewerGroup.md
+++ b/Docs/Help/Set-TeamViewerGroup.md
@@ -39,7 +39,7 @@ Changes a group in the Computers & Contacts list.
 PS /> Set-TeamViewerGroup -Group 'g1234' -Name 'New Group Name'
 ```
 
-Change the name of the group with the given group ID.
+Change the name of the group with the given group Id.
 
 ## PARAMETERS
 
@@ -78,8 +78,7 @@ Accept wildcard characters: False
 ### -Group
 
 Object that can be used to identify the group.
-This can either be the group ID or a group object that has been received using
-other module functions.
+This can either be the group Id or a group object that has been received using other module functions.
 
 ```yaml
 Type: Object

--- a/Docs/Help/Set-TeamViewerManagedDevice.md
+++ b/Docs/Help/Set-TeamViewerManagedDevice.md
@@ -20,15 +20,13 @@ Set-TeamViewerManagedDevice [-ApiToken] <SecureString> [-Device] <Object> [[-Nam
 
 ## DESCRIPTION
 
-Changes properties of a managed device. For example, the name of the managed
-device or the policy or the description can be changed.
+Changes properties of a managed device. For example, the name of the managed device or the policy or the description can be changed.
 You cannot combine any of those  three parameters together.
 
 For changing the device name, the current account needs `DeviceAdministration`
 manager permissions on the device.
 
-For changing the device's policy, the current account needs
-`PolicyAdministration` manager permissions on the device.
+For changing the device's policy, the current account needs `PolicyAdministration` manager permissions on the device.
 
 ## EXAMPLES
 
@@ -101,8 +99,7 @@ Accept wildcard characters: False
 ### -Device
 
 Object that can be used to identify the managed device.
-This can either be the managed device ID (as string or GUID) or a managed device
-object that has been received using other module functions.
+This can either be the managed device Id (as string or GUID) or a managed device object that has been received using other module functions.
 
 ```yaml
 Type: Object
@@ -135,8 +132,7 @@ Accept wildcard characters: False
 ### -Policy
 
 Object that can be used to identify the policy.
-This can either be the policy ID (as string or GUID) or a policy object that has
-been received using other module functions.
+This can either be the policy Id (as string or GUID) or a policy object that has been received using other module functions.
 
 ```yaml
 Type: Object
@@ -153,8 +149,7 @@ Accept wildcard characters: False
 ### -ManagedGroup
 
 Object that can be used to identify the managed group.
-This can either be the managed group ID (as string or GUID) or a managed group
-object that has been received using other module functions.
+This can either be the managed group Id (as string or GUID) or a managed group object that has been received using other module functions.
 
 ```yaml
 Type: Object

--- a/Docs/Help/Set-TeamViewerManagedGroup.md
+++ b/Docs/Help/Set-TeamViewerManagedGroup.md
@@ -29,9 +29,8 @@ Set-TeamViewerManagedGroup -ApiToken <SecureString> -Group <Object> -Property <H
 
 ## DESCRIPTION
 
-Changes properties of a managed group. For example, the name of the group can be
-changed. The current account needs `GroupAdministration` manager permissions on
-the group.
+Changes properties of a managed group. For example, the name of the group can be changed.
+The current account needs `GroupAdministration` manager permissions on the group.
 
 ## EXAMPLES
 
@@ -41,7 +40,7 @@ the group.
 PS /> Set-TeamViewerManagedGroup -Group '9fd16af0-c224-4242-998e-a7138b038dbb' -Name 'My New Group'
 ```
 
-Change the name of the managed group with the given ID.
+Change the name of the managed group with the given Id.
 
 ### Example 2
 
@@ -49,7 +48,7 @@ Change the name of the managed group with the given ID.
 PS /> Set-TeamviewerManagedGroup -GroupId '6808db5b-f3c1-4e42-8168-3ac96f5d456e' -PolicyId '926d7a7e-b640-43a9-bc95-4f71ed7e6878' -PolicyType 4
 ```
 
-Change the policy of the managed group with the given ID.
+Change the policy of the managed group with the given Id.
 
 ### Example 3
 
@@ -57,7 +56,7 @@ Change the policy of the managed group with the given ID.
 PS /> Set-TeamViewerManagedGroup -GroupId '6808db5b-f3c1-4e42-8168-3ac96f5d456e' -Property {'policy_id' = 'e563798b-b988-4917-b1d3-a012ce6ba929' 'policy_type' = 1}
 ```
 
-Change the policy of the managed group with the given ID using property parameters.
+Change the policy of the managed group with the given Id using property parameters.
 
 ## PARAMETERS
 
@@ -96,8 +95,7 @@ Accept wildcard characters: False
 ### -Group
 
 Object that can be used to identify the managed group.
-This can either be the managed group ID (as string or GUID) or a managed group
-object that has been received using other module functions.
+This can either be the managed group Id (as string or GUID) or a managed group object that has been received using other module functions.
 
 ```yaml
 Type: Object

--- a/Docs/Help/Set-TeamViewerManager.md
+++ b/Docs/Help/Set-TeamViewerManager.md
@@ -45,9 +45,8 @@ Set-TeamViewerManager -ApiToken <SecureString> -Manager <Object> [-Group <Object
 
 Changes permissions of a managed group manager or managed device manager.
 
-It is not possible to take away the `ManagerAdministration` permissions from
-all managers of a managed group or managed device. At least one manager must
-remain with that permission.
+It is not possible to take away the `ManagerAdministration` permissions from all managers of a managed group or managed device.
+At least one manager must remain with that permission.
 
 ## EXAMPLES
 
@@ -57,8 +56,7 @@ remain with that permission.
 PS /> Set-TeamViewerManager -Device 'c0cb303a-8a85-4e54-b657-a4757c791aef' -Manager '57e8f75e-8e6f-4450-a59d-10e02ccf5986' -Permissions 'EasyAccess', 'ManagerAdministration'
 ```
 
-Change the permissions of the given manager on the managed device with the given
-ID.
+Change the permissions of the given manager on the managed device with the given Id.
 
 ### Example 2
 
@@ -66,8 +64,7 @@ ID.
 PS /> Set-TeamViewerManager -Group '9fd16af0-c224-4242-998e-a7138b038dbb' -Manager '57e8f75e-8e6f-4450-a59d-10e02ccf5986' -Permissions 'EasyAccess', 'ManagerAdministration'
 ```
 
-Change the permissions of the given manager on the managed group with the given
-ID.
+Change the permissions of the given manager on the managed group with the given Id.
 
 ## PARAMETERS
 
@@ -106,8 +103,7 @@ Accept wildcard characters: False
 ### -Device
 
 Object that can be used to identify the managed device.
-This can either be the managed device ID (as string or GUID) or a managed device
-object that has been received using other module functions.
+This can either be the managed device Id (as string or GUID) or a managed device object that has been received using other module functions.
 
 ```yaml
 Type: Object
@@ -124,8 +120,7 @@ Accept wildcard characters: False
 ### -Group
 
 Object that can be used to identify the managed group.
-This can either be the managed group ID (as string or GUID) or a managed group
-object that has been received using other module functions.
+This can either be the managed group Id (as string or GUID) or a managed group object that has been received using other module functions.
 
 ```yaml
 Type: Object
@@ -142,8 +137,7 @@ Accept wildcard characters: False
 ### -Manager
 
 Object that can be used to identify the manager.
-This can either be the manager ID (as string or GUID) or a manager object that
-has been received using other module functions.
+This can either be the manager Id (as string or GUID) or a manager object that has been received using other module functions.
 
 ```yaml
 Type: Object
@@ -160,25 +154,13 @@ Accept wildcard characters: False
 ### -Permissions
 
 Permissions to give to the manager.
-An empty set of permissions still allows read-only access on the device/group
-data. Multiple values can be specified.
+An empty set of permissions still allows read-only access on the device/group data. Multiple values can be specified.
 
-`ManagerAdministration` allows the manager to change other managers on the given
-device or group.
-
-`DeviceAdministration` (only for managed devices) allows the manager to change
-device-specific properties, e.g. the device name. Also reqruied to add devices
-to managed groups.
-
-`GroupAdministration` (only for managed groups) allows the manager to change
-group-specific properties, e.g. the group name. Also required to add managed
-devices to the group.
-
-`PolicyAdministration` (only for managed devices) allows the manager to change
-the policy that has been assigned to the managed device.
-
-`EasyAccess` allows the manager to connect to the device (or the devices of the
-group) via "EasyAccess" (without additional password).
+`ManagerAdministration` allows the manager to change other managers on the given device or group.
+`DeviceAdministration` (only for managed devices) allows the manager to change device-specific properties, e.g. the device name. Also reqruied to add devices to managed groups.
+`GroupAdministration` (only for managed groups) allows the manager to change group-specific properties, e.g. the group name. Also required to add managed devices to the group.
+`PolicyAdministration` (only for managed devices) allows the manager to change the policy that has been assigned to the managed device.
+`EasyAccess` allows the manager to connect to the device (or the devices of the group) via "EasyAccess" (without additional password).
 
 ```yaml
 Type: String[]

--- a/Docs/Help/Set-TeamViewerPolicy.md
+++ b/Docs/Help/Set-TeamViewerPolicy.md
@@ -94,8 +94,7 @@ Accept wildcard characters: False
 ### -Policy
 
 Object that can be used to identify the policy.
-This can either be the policy ID (as string or GUID) or a policy object that has
-been received using other module functions.
+This can either be the policy Id (as string or GUID) or a policy object that has been received using other module functions.
 
 ```yaml
 Type: Object
@@ -132,11 +131,8 @@ Change settings of the TeamViewer policy.
 Must be objects with the following properties:
 
 `key`: The label of a setting
-
 `value`: The value of a setting
-
-`enforce`: `true` or `false`. Enforced settings cannot be changed on the device
-itself.
+`enforce`: `true` or `false`. Enforced settings cannot be changed on the device itself.
 
 ```yaml
 Type: Object[]

--- a/Docs/Help/Set-TeamViewerUser.md
+++ b/Docs/Help/Set-TeamViewerUser.md
@@ -207,7 +207,7 @@ Accept wildcard characters: False
 
 ### -CustomQuickSupportId
 
-Specifies the ID of a custom QuickSupport module assigned to the user.
+Specifies the Id of a custom QuickSupport module assigned to the user.
 
 ```yaml
 Type: String
@@ -223,7 +223,7 @@ Accept wildcard characters: False
 
 ### -CustomQuickJoinId
 
-Specifies the ID of a custom QuickJoin module assigned to the user.
+Specifies the Id of a custom QuickJoin module assigned to the user.
 
 ```yaml
 Type: String
@@ -355,7 +355,7 @@ Accept wildcard characters: False
 ### -User
 
 Object that can be used to identify the user.
-This can either be the user ID or a user object that has been received using other module functions.
+This can either be the user Id or a user object that has been received using other module functions.
 
 ```yaml
 Type: Object

--- a/Docs/Help/Unpublish-TeamViewerGroup.md
+++ b/Docs/Help/Unpublish-TeamViewerGroup.md
@@ -67,8 +67,7 @@ Accept wildcard characters: False
 ### -Group
 
 Object that can be used to identify the group.
-This can either be the group ID or a group object that has been received using
-other module functions.
+This can either be the group Id or a group object that has been received using other module functions.
 
 ```yaml
 Type: Object
@@ -85,8 +84,7 @@ Accept wildcard characters: False
 ### -User
 
 Object that can be used to identify the user.
-This can either be the user ID or a user object that has been received using
-other module functions.
+This can either be the user Id or a user object that has been received using other module functions.
 
 ```yaml
 Type: Object[]

--- a/Tests/Private/ConvertTo-TeamViewerAuditEvent.Tests.ps1
+++ b/Tests/Private/ConvertTo-TeamViewerAuditEvent.Tests.ps1
@@ -13,6 +13,6 @@ Describe 'ConvertTo-TeamViewerAuditEvent' {
         $Result = ConvertTo-TeamViewerAuditEvent -InputObject $InputObject
 
         $Result.PSObject.TypeNames[0] | Should -Be 'TeamViewerPS.AuditEvent'
-        $Result.Timestamp | Should -BeOfType ([datetime])
+        $Result.CreatedAt | Should -BeOfType ([datetime])
     }
 }

--- a/Tests/Private/ConvertTo-TeamViewerCompany.Tests.ps1
+++ b/Tests/Private/ConvertTo-TeamViewerCompany.Tests.ps1
@@ -17,8 +17,8 @@ Describe 'ConvertTo-TeamViewerCompany' {
 
             $Result = $companyInput | ConvertTo-TeamViewerCompany
 
-            $Result.CompanyId | Should -Be 42
-            $Result.CompanyName | Should -Be 'Acme Corp'
+            $Result.Id | Should -Be 42
+            $Result.Name | Should -Be 'Acme Corp'
             $Result.CreatedAt | Should -Be ([datetime]'2026-08-10T12:34:56Z')
         }
 
@@ -63,8 +63,8 @@ Describe 'ConvertTo-TeamViewerCompany' {
 
             $Result = $companyInput | ConvertTo-TeamViewerCompany
 
-            $Result.CompanyId | Should -Be 7
-            $Result.CompanyId.GetType().Name | Should -Be 'Int32'
+            $Result.Id | Should -Be 7
+            $Result.Id.GetType().Name | Should -Be 'Int32'
         }
     }
 
@@ -77,12 +77,12 @@ Describe 'ConvertTo-TeamViewerCompany' {
 
             $Result = $companyInput | ConvertTo-TeamViewerCompany
 
-            $Result.PSObject.Properties.Name | Should -Contain 'CompanyId'
-            $Result.PSObject.Properties.Name | Should -Contain 'CompanyName'
+            $Result.PSObject.Properties.Name | Should -Contain 'Id'
+            $Result.PSObject.Properties.Name | Should -Contain 'Name'
             $Result.PSObject.Properties.Name | Should -Contain 'CreatedAt'
         }
 
-        It 'Should expose TeamViewerPS.Company type name and custom ToString output' {
+        It 'Should expose TeamViewerPS.Company type name' {
             $companyInput = [pscustomobject]@{
                 companyId   = 5
                 companyName = 'Contoso'
@@ -91,7 +91,6 @@ Describe 'ConvertTo-TeamViewerCompany' {
             $Result = $companyInput | ConvertTo-TeamViewerCompany
 
             $Result.PSObject.TypeNames[0] | Should -Be 'TeamViewerPS.Company'
-            $Result.ToString() | Should -Be 'Contoso'
         }
     }
 
@@ -105,8 +104,8 @@ Describe 'ConvertTo-TeamViewerCompany' {
             $Results = $InputObjects | ConvertTo-TeamViewerCompany
 
             @($Results).Count | Should -Be 2
-            $Results[0].CompanyName | Should -Be 'Alpha'
-            $Results[1].CompanyName | Should -Be 'Beta'
+            $Results[0].Name | Should -Be 'Alpha'
+            $Results[1].Name | Should -Be 'Beta'
             $Results[1].CreatedAt | Should -BeNull
         }
     }

--- a/Tests/Private/ConvertTo-TeamViewerConnectionReport.Tests.ps1
+++ b/Tests/Private/ConvertTo-TeamViewerConnectionReport.Tests.ps1
@@ -9,12 +9,12 @@ BeforeAll {
 
 Describe 'ConvertTo-TeamViewerConnectionReport' {
     It 'Maps report properties and converts start/end dates' {
-        $InputObject = [pscustomobject]@{ id='1'; userid='u1'; username='User'; deviceid='d1'; devicename='Device'; groupid='g1'; groupname='Group'; support_session_type='1'; start_date='2026-01-01'; end_date='2026-01-02'; session_code='s1'; fee='10'; billing_state='b'; currency='EUR'; notes='n' }
+        $InputObject = [pscustomobject]@{ id = '1'; userid = 'u1'; username = 'User'; deviceid = 'd1'; devicename = 'Device'; groupid = 'g1'; groupname = 'Group'; support_session_type = '1'; start_date = '2026-01-01'; end_date = '2026-01-02'; session_code = 's1'; fee = '10'; billing_state = 'b'; currency = 'EUR'; notes = 'n' }
 
         $Result = ConvertTo-TeamViewerConnectionReport -InputObject $InputObject
 
         $Result.PSObject.TypeNames[0] | Should -Be 'TeamViewerPS.ConnectionReport'
-        $Result.StartDate | Should -BeOfType ([datetime])
-        $Result.EndDate | Should -BeOfType ([datetime])
+        $Result.Datetime_Start | Should -BeOfType ([datetime])
+        $Result.Datetime_End | Should -BeOfType ([datetime])
     }
 }

--- a/Tests/Private/ConvertTo-TeamViewerDeviceCustomField.Tests.ps1
+++ b/Tests/Private/ConvertTo-TeamViewerDeviceCustomField.Tests.ps1
@@ -11,10 +11,9 @@ Describe 'ConvertTo-TeamViewerDeviceCustomField' {
 
         $Result = $InputObject | ConvertTo-TeamViewerDeviceCustomField
 
-        $Result.FieldKeyId | Should -Be '00000000-0000-0000-0000-000000000001'
+        $Result.Id | Should -Be '00000000-0000-0000-0000-000000000001'
         $Result.Value | Should -Be 'AssetTag001'
         $Result.PSObject.TypeNames | Should -Contain 'TeamViewerPS.DeviceCustomField'
-        $Result.ToString() | Should -Be 'AssetTag001'
     }
 
     It 'Should convert multiple pipeline inputs' {

--- a/Tests/Private/ConvertTo-TeamViewerDeviceCustomFieldConfiguration.Tests.ps1
+++ b/Tests/Private/ConvertTo-TeamViewerDeviceCustomFieldConfiguration.Tests.ps1
@@ -17,7 +17,7 @@ Describe 'ConvertTo-TeamViewerDeviceCustomFieldConfiguration' {
         $Result = $InputObject | ConvertTo-TeamViewerDeviceCustomFieldConfiguration
 
         $Result.Id | Should -Be $InputObject.fieldKeyId
-        $Result.Key | Should -Be 'AssetTag'
+        $Result.Name | Should -Be 'AssetTag'
         $Result.Type | Should -Be 'string'
         $Result.Description | Should -Be 'Device asset tag'
         $Result.CreatedAt | Should -BeOfType ([datetime])
@@ -34,6 +34,6 @@ Describe 'ConvertTo-TeamViewerDeviceCustomFieldConfiguration' {
         ) | ConvertTo-TeamViewerDeviceCustomFieldConfiguration
 
         $Results.Count | Should -Be 2
-        $Results.Key | Should -Be @('One', 'Two')
+        $Results.Name | Should -Be @('One', 'Two')
     }
 }

--- a/Tests/Private/ConvertTo-TeamViewerDeviceCustomFieldConfiguration.Tests.ps1
+++ b/Tests/Private/ConvertTo-TeamViewerDeviceCustomFieldConfiguration.Tests.ps1
@@ -17,15 +17,14 @@ Describe 'ConvertTo-TeamViewerDeviceCustomFieldConfiguration' {
         $Result = $InputObject | ConvertTo-TeamViewerDeviceCustomFieldConfiguration
 
         $Result.Id | Should -Be $InputObject.fieldKeyId
-        $Result.FieldKey | Should -Be 'AssetTag'
-        $Result.FieldType | Should -Be 'string'
+        $Result.Key | Should -Be 'AssetTag'
+        $Result.Type | Should -Be 'string'
         $Result.Description | Should -Be 'Device asset tag'
         $Result.CreatedAt | Should -BeOfType ([datetime])
         $Result.CreatedAt | Should -Be ([datetime]'2026-01-01T00:00:00Z')
         $Result.UpdatedAt | Should -BeOfType ([datetime])
         $Result.UpdatedAt | Should -Be ([datetime]'2026-01-02T00:00:00Z')
         $Result.PSObject.TypeNames | Should -Contain 'TeamViewerPS.DeviceCustomFieldConfiguration'
-        $Result.ToString() | Should -Be 'AssetTag (00000000-0000-0000-0000-000000000001)'
     }
 
     It 'Should convert multiple pipeline inputs' {
@@ -35,6 +34,6 @@ Describe 'ConvertTo-TeamViewerDeviceCustomFieldConfiguration' {
         ) | ConvertTo-TeamViewerDeviceCustomFieldConfiguration
 
         $Results.Count | Should -Be 2
-        $Results.FieldKey | Should -Be @('One', 'Two')
+        $Results.Key | Should -Be @('One', 'Two')
     }
 }

--- a/Tests/Private/ConvertTo-TeamViewerGroup.Tests.ps1
+++ b/Tests/Private/ConvertTo-TeamViewerGroup.Tests.ps1
@@ -13,7 +13,7 @@ Describe 'ConvertTo-TeamViewerGroup' {
         $Result = ConvertTo-TeamViewerGroup -InputObject $InputObject
 
         $Result.PSObject.TypeNames[0] | Should -Be 'TeamViewerPS.Group'
-        $Result.SharedWith.Count | Should -Be 1
-        $Result.SharedWith[0].PSObject.TypeNames[0] | Should -Be 'TeamViewerPS.GroupShare'
+        $Result.Shared_With.Count | Should -Be 1
+        $Result.Shared_With[0].PSObject.TypeNames[0] | Should -Be 'TeamViewerPS.GroupShare'
     }
 }

--- a/Tests/Private/ConvertTo-TeamViewerLicense.Tests.ps1
+++ b/Tests/Private/ConvertTo-TeamViewerLicense.Tests.ps1
@@ -18,8 +18,8 @@ Describe 'ConvertTo-TeamViewerLicense' {
         $Result = ConvertTo-TeamViewerLicense -InputObject $InputObject
 
         $Result.PSObject.TypeNames[0] | Should -Be 'TeamViewerPS.License'
-        $Result.CompanyId | Should -Be 42
-        $Result.AvailableLicenses.Count | Should -Be 1
-        $Result.AvailableLicenses[0].PSObject.TypeNames[0] | Should -Be 'TeamViewerPS.LicenseInformation'
+        $Result.Id | Should -Be 42
+        $Result.Licenses_Available.Count | Should -Be 1
+        $Result.Licenses_Available[0].PSObject.TypeNames[0] | Should -Be 'TeamViewerPS.LicenseInformation'
     }
 }

--- a/Tests/Private/ConvertTo-TeamViewerLicenseInformation.Tests.ps1
+++ b/Tests/Private/ConvertTo-TeamViewerLicenseInformation.Tests.ps1
@@ -28,7 +28,7 @@ Describe 'ConvertTo-TeamViewerLicenseInformation' {
 
         $Result | Should -Not -BeNullOrEmpty
         $Result.PSObject.TypeNames[0] | Should -Be 'TeamViewerPS.LicenseInformation'
-        $Result.LicenseName | Should -Be 'Tensor'
+        $Result.Name | Should -Be 'Tensor'
     }
 
     It 'Supports pipeline processing of multiple items' {

--- a/Tests/Private/ConvertTo-TeamViewerManager.Tests.ps1
+++ b/Tests/Private/ConvertTo-TeamViewerManager.Tests.ps1
@@ -13,7 +13,7 @@ Describe 'ConvertTo-TeamViewerManager' {
         $Result = ConvertTo-TeamViewerManager -InputObject $InputObject -GroupId $GroupId
 
         $Result.PSObject.TypeNames[0] | Should -Be 'TeamViewerPS.Manager'
-        $Result.GroupId | Should -Be $GroupId
+        $Result.Group_Id | Should -Be $GroupId
     }
 
     It 'Sets DeviceId when using DeviceManager parameter set' {
@@ -23,6 +23,6 @@ Describe 'ConvertTo-TeamViewerManager' {
         $Result = ConvertTo-TeamViewerManager -InputObject $InputObject -DeviceId $DeviceId
 
         $Result.PSObject.TypeNames[0] | Should -Be 'TeamViewerPS.Manager'
-        $Result.DeviceId | Should -Be $DeviceId
+        $Result.Device_Id | Should -Be $DeviceId
     }
 }

--- a/Tests/Private/ConvertTo-TeamViewerRoleAssignedUser.Tests.ps1
+++ b/Tests/Private/ConvertTo-TeamViewerRoleAssignedUser.Tests.ps1
@@ -10,6 +10,6 @@ Describe 'ConvertTo-TeamViewerRoleAssignedUser' {
         $Result = 'u12345' | ConvertTo-TeamViewerRoleAssignedUser
 
         $Result.PSObject.TypeNames[0] | Should -Be 'TeamViewerPS.RoleAssignedUser'
-        $Result.AssignedUsers | Should -Be '12345'
+        $Result.Assigned_Users | Should -Be '12345'
     }
 }

--- a/Tests/Private/ConvertTo-TeamViewerRoleAssignedUserGroup.Tests.ps1
+++ b/Tests/Private/ConvertTo-TeamViewerRoleAssignedUserGroup.Tests.ps1
@@ -10,6 +10,6 @@ Describe 'ConvertTo-TeamViewerRoleAssignedUserGroup' {
         $Result = 'g12345' | ConvertTo-TeamViewerRoleAssignedUserGroup
 
         $Result.PSObject.TypeNames[0] | Should -Be 'TeamViewerPS.RoleAssignedUserGroup'
-        $Result.AssignedGroups | Should -Be 'g12345'
+        $Result.Assigned_UserGroups | Should -Be 'g12345'
     }
 }

--- a/Tests/Private/ConvertTo-TeamViewerUser.Tests.ps1
+++ b/Tests/Private/ConvertTo-TeamViewerUser.Tests.ps1
@@ -10,12 +10,12 @@ Describe 'ConvertTo-TeamViewerUser' {
     It 'Loads all properties by default' {
         $InputObject = [pscustomobject]@{ id='u1'; name='User'; email='u@example.com'; active=$true; last_access_date='2026-01-01'; tfa_enforcement='off'; tfa_enabled=$false; log_sessions=$true; show_comment_window=$false; sso_status='none' }
 
-        $Result = ConvertTo-TeamViewerUser -InputObject $InputObject
+        $Result = ConvertTo-TeamViewerUser -InputObject $InputObject -PropertiesToLoad All
 
         $Result.PSObject.TypeNames[0] | Should -Be 'TeamViewerPS.User'
         $Result.PSObject.Properties.Name | Should -Contain 'Active'
-        $Result.LastAccessDate | Should -BeOfType ([datetime])
-        $Result.LastAccessDate | Should -Be ([datetime]'2026-01-01')
+        $Result.LastAccess_Date | Should -BeOfType ([datetime])
+        $Result.LastAccess_Date | Should -Be ([datetime]'2026-01-01')
     }
 
     It 'Loads minimal property set when requested' {

--- a/Tests/Private/ConvertTo-TeamViewerUserGroupAssignedRole.Tests.ps1
+++ b/Tests/Private/ConvertTo-TeamViewerUserGroupAssignedRole.Tests.ps1
@@ -7,7 +7,7 @@ BeforeAll {
 
 Describe 'ConvertTo-TeamViewerUserGroupAssignedRole' {
     It 'Creates TeamViewerPS.UserGroupAssignedRole object' {
-        $Result = 'g12345' | ConvertTo-TeamViewerRoleAssignedUserGroup
+        $Result = 'g12345' | ConvertTo-TeamViewerUserGroupAssignedRole
 
         $Result.PSObject.TypeNames[0] | Should -Be 'TeamViewerPS.UserGroupAssignedRole'
         $Result.Assigned_UserGroups | Should -Be 'g12345'

--- a/Tests/Private/ConvertTo-TeamViewerUserGroupAssignedRole.Tests.ps1
+++ b/Tests/Private/ConvertTo-TeamViewerUserGroupAssignedRole.Tests.ps1
@@ -10,6 +10,6 @@ Describe 'ConvertTo-TeamViewerUserGroupAssignedRole' {
         $Result = 'g12345' | ConvertTo-TeamViewerRoleAssignedUserGroup
 
         $Result.PSObject.TypeNames[0] | Should -Be 'TeamViewerPS.UserGroupAssignedRole'
-        $Result.AssignedGroups | Should -Be 'g12345'
+        $Result.Assigned_UserGroups | Should -Be 'g12345'
     }
 }

--- a/Tests/Private/Resolve-TeamViewerRoleId.Tests.ps1
+++ b/Tests/Private/Resolve-TeamViewerRoleId.Tests.ps1
@@ -6,8 +6,8 @@ BeforeAll {
 }
 
 Describe 'Resolve-TeamViewerRoleId' {
-    It 'Returns RoleID from TeamViewerPS.Role object' {
-        $role = [pscustomobject]@{ RoleID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' }
+    It 'Returns ID from TeamViewerPS.Role object' {
+        $role = [pscustomobject]@{ ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' }
         $role.PSObject.TypeNames.Insert(0, 'TeamViewerPS.Role')
 
         Resolve-TeamViewerRoleId -Role $role | Should -Be 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'

--- a/Tests/Private/Resolve-TeamViewerRoleId.Tests.ps1
+++ b/Tests/Private/Resolve-TeamViewerRoleId.Tests.ps1
@@ -6,8 +6,8 @@ BeforeAll {
 }
 
 Describe 'Resolve-TeamViewerRoleId' {
-    It 'Returns ID from TeamViewerPS.Role object' {
-        $role = [pscustomobject]@{ ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' }
+    It 'Returns Id from TeamViewerPS.Role object' {
+        $role = [pscustomobject]@{ Id = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' }
         $role.PSObject.TypeNames.Insert(0, 'TeamViewerPS.Role')
 
         Resolve-TeamViewerRoleId -Role $role | Should -Be 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'

--- a/Tests/Private/Resolve-TeamViewerUserGroupMemberId.Tests.ps1
+++ b/Tests/Private/Resolve-TeamViewerUserGroupMemberId.Tests.ps1
@@ -6,8 +6,8 @@ BeforeAll {
 }
 
 Describe 'Resolve-TeamViewerUserGroupMemberId' {
-    It 'Returns AccountId from TeamViewerPS.UserGroupMember object' {
-        $member = [pscustomobject]@{ AccountId = 'u123456' }
+    It 'Returns ID from TeamViewerPS.UserGroupMember object' {
+        $member = [pscustomobject]@{ Id = 'u123456' }
         $member.PSObject.TypeNames.Insert(0, 'TeamViewerPS.UserGroupMember')
 
         Resolve-TeamViewerUserGroupMemberMemberId -UserGroupMember $member | Should -Be 'u123456'

--- a/Tests/Private/Resolve-TeamViewerUserGroupMemberId.Tests.ps1
+++ b/Tests/Private/Resolve-TeamViewerUserGroupMemberId.Tests.ps1
@@ -6,22 +6,22 @@ BeforeAll {
 }
 
 Describe 'Resolve-TeamViewerUserGroupMemberId' {
-    It 'Returns ID from TeamViewerPS.UserGroupMember object' {
+    It 'Returns Id from TeamViewerPS.UserGroupMember object' {
         $member = [pscustomobject]@{ Id = 'u123456' }
         $member.PSObject.TypeNames.Insert(0, 'TeamViewerPS.UserGroupMember')
 
-        Resolve-TeamViewerUserGroupMemberMemberId -UserGroupMember $member | Should -Be 'u123456'
+        Resolve-TeamViewerUserGroupMemberId -UserGroupMember $member | Should -Be 'u123456'
     }
 
     It 'Returns user id pattern unchanged' {
-        Resolve-TeamViewerUserGroupMemberMemberId -UserGroupMember 'u123456' | Should -Be 'u123456'
+        Resolve-TeamViewerUserGroupMemberId -UserGroupMember 'u123456' | Should -Be 'u123456'
     }
 
     It 'Converts numeric string to int' {
-        Resolve-TeamViewerUserGroupMemberMemberId -UserGroupMember '42' | Should -Be 42
+        Resolve-TeamViewerUserGroupMemberId -UserGroupMember '42' | Should -Be 42
     }
 
     It 'Returns int unchanged' {
-        Resolve-TeamViewerUserGroupMemberMemberId -UserGroupMember 42 | Should -Be 42
+        Resolve-TeamViewerUserGroupMemberId -UserGroupMember 42 | Should -Be 42
     }
 }

--- a/Tests/Private/Test-FunctionNamesAndFileNames.Tests.ps1
+++ b/Tests/Private/Test-FunctionNamesAndFileNames.Tests.ps1
@@ -1,0 +1,58 @@
+BeforeDiscovery {
+    $Script:Module_RootPath = (Resolve-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath '..\..'))
+    $Script:Module_CmdletsPath = Join-Path -Path $Module_RootPath -ChildPath 'Cmdlets'
+
+    $Script:FunctionTestCases = @('Private', 'Public') | ForEach-Object {
+        $FunctionType = $_
+        $FunctionPath = Join-Path -Path $Module_CmdletsPath -ChildPath $FunctionType
+
+        Get-ChildItem -Path $FunctionPath -Filter '*.ps1' -File | ForEach-Object {
+            @{
+                FunctionName = $_.BaseName
+                FunctionPath = $FunctionPath
+                FunctionType = $FunctionType
+            }
+        }
+    }
+}
+
+Describe 'Test-FunctionNamesAndFileNames' {
+    It '<FunctionType> function file name matches its top-level function name: <FunctionName>' -TestCases $FunctionTestCases {
+        param(
+            [string]$FunctionName,
+            [string]$FunctionPath
+        )
+
+        $FunctionFilePath = Join-Path -Path $FunctionPath -ChildPath "$FunctionName.ps1"
+
+        $Tokens = $null
+        $ParseErrors = $null
+
+        $Ast = [System.Management.Automation.Language.Parser]::ParseFile($FunctionFilePath, [ref]$Tokens, [ref]$ParseErrors)
+
+        $ParseErrors | Should -BeNullOrEmpty
+
+        $TopLevelFunctions = @($Ast.FindAll({
+                    param($Node)
+                    if ($Node -isnot [System.Management.Automation.Language.FunctionDefinitionAst] -or
+                        $Node.Parent -isnot [System.Management.Automation.Language.NamedBlockAst]) {
+                        return $false
+                    }
+
+                    $Parent = $Node.Parent.Parent
+                    while ($Parent) {
+                        if ($Parent -is [System.Management.Automation.Language.FunctionDefinitionAst] -or
+                            $Parent -is [System.Management.Automation.Language.FunctionMemberAst]) {
+                            return $false
+                        }
+
+                        $Parent = $Parent.Parent
+                    }
+
+                    return $true
+                }, $true))
+
+        $TopLevelFunctions | Should -HaveCount 1
+        $TopLevelFunctions[0].Name | Should -Be $FunctionName
+    }
+}

--- a/Tests/Public/Add-TeamViewerManager.Tests.ps1
+++ b/Tests/Public/Add-TeamViewerManager.Tests.ps1
@@ -78,7 +78,7 @@ Describe 'Add-TeamViewerManager' {
         }
     }
 
-    It 'Should accept manager ID as input' {
+    It 'Should accept manager Id as input' {
         Add-TeamViewerManager -ApiToken $testApiToken -GroupId $testGroupId -ManagerId $testManagerId
 
         $mockArgs.Body | Should -Not -BeNullOrEmpty
@@ -106,7 +106,7 @@ Describe 'Add-TeamViewerManager' {
         $Body.accountId | Should -Be 123456
     }
 
-    It 'Should accept a user group ID as input' {
+    It 'Should accept a user group Id as input' {
         $TestUserGroupId = [uint64]123456
 
         Add-TeamViewerManager -ApiToken $testApiToken -GroupId $testGroupId -UserGroupId $TestUserGroupId

--- a/Tests/Public/Get-TeamViewerCompany.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerCompany.Tests.ps1
@@ -27,8 +27,7 @@ Describe 'Get-TeamViewerCompany' {
         $Result = Get-TeamViewerCompany -ApiToken $testApiToken
         $Result | Should -Not -BeNullOrEmpty
         $Result.PSObject.TypeNames | Should -Contain 'TeamViewerPS.Company'
-        $Result.CompanyId | Should -Be 42
-        $Result.CompanyName | Should -Be 'TeamViewer Germany GmbH'
-        $Result.ToString() | Should -Be 'TeamViewer Germany GmbH'
+        $Result.Id | Should -Be 42
+        $Result.Name | Should -Be 'TeamViewer Germany GmbH'
     }
 }

--- a/Tests/Public/Get-TeamViewerCustomModuleId.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerCustomModuleId.Tests.ps1
@@ -60,7 +60,7 @@ Describe 'Get-TeamViewerCustomModuleId' {
             $Result | Should -BeNullOrEmpty
 
             Should -Invoke Write-Verbose -Scope It -Times 1 -ParameterFilter {
-                $Message -like 'Failed to read the custom module ID from*invalid JSON'
+                $Message -like 'Failed to read the custom module Id from*invalid JSON'
             }
         }
     }

--- a/Tests/Public/Get-TeamViewerDeviceCustomFieldConfiguration.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerDeviceCustomFieldConfiguration.Tests.ps1
@@ -15,7 +15,7 @@ Describe 'Get-TeamViewerDeviceCustomFieldConfiguration' {
 
         $Result = Get-TeamViewerDeviceCustomFieldConfiguration -ApiToken $testApiToken
 
-        $Result.Key | Should -Be 'AssetTag'
+        $Result.Name | Should -Be 'AssetTag'
         $Result.PSObject.TypeNames | Should -Contain 'TeamViewerPS.DeviceCustomFieldConfiguration'
 
         Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {

--- a/Tests/Public/Get-TeamViewerDeviceCustomFieldConfiguration.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerDeviceCustomFieldConfiguration.Tests.ps1
@@ -15,7 +15,7 @@ Describe 'Get-TeamViewerDeviceCustomFieldConfiguration' {
 
         $Result = Get-TeamViewerDeviceCustomFieldConfiguration -ApiToken $testApiToken
 
-        $Result.FieldKey | Should -Be 'AssetTag'
+        $Result.Key | Should -Be 'AssetTag'
         $Result.PSObject.TypeNames | Should -Contain 'TeamViewerPS.DeviceCustomFieldConfiguration'
 
         Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {

--- a/Tests/Public/Get-TeamViewerGroup.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerGroup.Tests.ps1
@@ -67,11 +67,11 @@ Describe 'Get-TeamViewerGroup' {
 
     It 'Should include PolicyId when getting single group' {
         $Result = Get-TeamViewerGroup -ApiToken $testApiToken -Id 'g1234'
-        $Result.PolicyId | Should -Be 'p1234'
+            $Result.Policy_Id | Should -Be 'p1234'
     }
 
     It 'Should include PolicyId when filtering groups' {
         $Result = Get-TeamViewerGroup -ApiToken $testApiToken
-        $Result[0].PolicyId | Should -Be 'p1234'
+            $Result[0].Policy_Id | Should -Be 'p1234'
     }
 }

--- a/Tests/Public/Get-TeamViewerId.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerId.Tests.ps1
@@ -12,7 +12,7 @@ Describe 'Get-TeamViewerId' {
         Mock Test-TeamViewerInstallation { $true }
     }
 
-    It 'Should return the TeamViewer ID from the Windows Registry' {
+    It 'Should return the TeamViewer Id from the Windows Registry' {
         Get-TeamViewerId | Should -Be 123456
 
         Should -Invoke Get-ItemPropertyValue -Scope It -Times 1 -ParameterFilter {

--- a/Tests/Public/Get-TeamViewerLicense.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerLicense.Tests.ps1
@@ -44,11 +44,10 @@ Describe 'Get-TeamViewerLicense' {
         $Result = Get-TeamViewerLicense -ApiToken $testApiToken
         $Result | Should -Not -BeNullOrEmpty
         $Result.PSObject.TypeNames | Should -Contain 'TeamViewerPS.License'
-        $Result.CompanyId | Should -Be 42
-        $Result.CompanyName | Should -Be 'TeamViewer Germany GmbH'
-        $Result.AvailableLicenses | Should -HaveCount 1
-        $Result.AvailableLicenses[0].PSObject.TypeNames | Should -Contain 'TeamViewerPS.LicenseInformation'
-        $Result.AvailableLicenses[0].LicenseName | Should -Be 'Tensor'
-        $Result.ToString() | Should -Be 'TeamViewer Germany GmbH'
+        $Result.Id | Should -Be 42
+        $Result.Name | Should -Be 'TeamViewer Germany GmbH'
+        $Result.Licenses_Available | Should -HaveCount 1
+        $Result.Licenses_Available[0].PSObject.TypeNames | Should -Contain 'TeamViewerPS.LicenseInformation'
+        $Result.Licenses_Available[0].Name | Should -Be 'Tensor'
     }
 }

--- a/Tests/Public/Get-TeamViewerManagementId.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerManagementId.Tests.ps1
@@ -29,7 +29,7 @@ Describe 'Get-TeamViewerManagementId' {
         Mock Test-TeamViewerInstallation { $true }
     }
 
-    It 'Should return the Management ID from the Windows Registry' {
+    It 'Should return the Management Id from the Windows Registry' {
         Get-TeamViewerManagementId | Should -Be $testManagementId
 
         Should -Invoke Test-TeamViewerInstallation -Scope It -Times 1

--- a/Tests/Public/Get-TeamViewerManager.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerManager.Tests.ps1
@@ -45,14 +45,14 @@ Describe 'Get-TeamViewerManager' {
             $Result | Should -HaveCount 2
             $Result[0].PSObject.TypeNames | Should -Contain 'TeamViewerPS.Manager'
             $Result[0].Name | Should -Be 'test manager 1'
-            $Result[0].GroupId | Should -Be $testGroupId
+            $Result[0].Group_Id | Should -Be $testGroupId
         }
 
         It 'Should handle group objects as input' {
             $testGroup = @{id = $testGroupId; name = 'test managed group' } | ConvertTo-TeamViewerManagedGroup
             $Result = Get-TeamViewerManager -ApiToken $testApiToken -Group $testGroup
             $Result | Should -HaveCount 2
-            $Result[0].GroupId | Should -Be $testGroupId
+            $Result[0].Group_Id | Should -Be $testGroupId
         }
     }
 
@@ -69,14 +69,14 @@ Describe 'Get-TeamViewerManager' {
             $Result | Should -HaveCount 2
             $Result[0].PSObject.TypeNames | Should -Contain 'TeamViewerPS.Manager'
             $Result[0].Name | Should -Be 'test manager 1'
-            $Result[0].DeviceId | Should -Be $testDeviceId
+            $Result[0].Device_Id | Should -Be $testDeviceId
         }
 
         It 'Should handle device objects as input' {
             $testDevice = @{id = $testDeviceId; name = 'test managed device' } | ConvertTo-TeamViewerManagedDevice
             $Result = Get-TeamViewerManager -ApiToken $testApiToken -Device $testDevice
             $Result | Should -HaveCount 2
-            $Result[0].DeviceId | Should -Be $testDeviceId
+            $Result[0].Device_Id | Should -Be $testDeviceId
         }
     }
 }

--- a/Tests/Public/Get-TeamViewerPredefinedRole.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerPredefinedRole.Tests.ps1
@@ -29,7 +29,7 @@ Describe 'Get-TeamViewerPredefinedRole' {
 
         $Result | Should -BeOfType [PSCustomObject]
         $Result.PSObject.TypeNames | Should -Contain 'TeamViewerPS.PredefinedRole'
-        $Result.PredefinedRoleID | Should -Be 'a9c9435d-8544-4e6a-9830-9337078c9aab'
+        $Result.Role_Id | Should -Be 'a9c9435d-8544-4e6a-9830-9337078c9aab'
     }
 
     It 'Should return PredefinedRole objects' {

--- a/Tests/Public/Get-TeamViewerRole.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerRole.Tests.ps1
@@ -45,7 +45,7 @@ Describe 'Get-TeamViewerRole' {
         $Result | Should -BeOfType [PSCustomObject]
         $Result.PSObject.TypeNames | Should -Contain 'TeamViewerPS.Role'
         $Result.Name | Should -Be 'Role 1'
-        $Result.ID | Should -Be 'a9c9435d-8544-4e6a-9830-9337078c9aab'
+        $Result.Id | Should -Be 'a9c9435d-8544-4e6a-9830-9337078c9aab'
         $Result.AllowGroupSharing | Should -Be $true
         $Result.ManageAdmins | Should -Be $false
         $Result.ManageUsers | Should -Be $true

--- a/Tests/Public/Get-TeamViewerRole.Tests.ps1
+++ b/Tests/Public/Get-TeamViewerRole.Tests.ps1
@@ -44,8 +44,8 @@ Describe 'Get-TeamViewerRole' {
 
         $Result | Should -BeOfType [PSCustomObject]
         $Result.PSObject.TypeNames | Should -Contain 'TeamViewerPS.Role'
-        $Result.RoleName | Should -Be 'Role 1'
-        $Result.RoleID | Should -Be 'a9c9435d-8544-4e6a-9830-9337078c9aab'
+        $Result.Name | Should -Be 'Role 1'
+        $Result.ID | Should -Be 'a9c9435d-8544-4e6a-9830-9337078c9aab'
         $Result.AllowGroupSharing | Should -Be $true
         $Result.ManageAdmins | Should -Be $false
         $Result.ManageUsers | Should -Be $true

--- a/Tests/Public/New-TeamViewerDeviceCustomFieldConfiguration.Tests.ps1
+++ b/Tests/Public/New-TeamViewerDeviceCustomFieldConfiguration.Tests.ps1
@@ -15,7 +15,7 @@ Describe 'New-TeamViewerDeviceCustomFieldConfiguration' {
 
         $Result = New-TeamViewerDeviceCustomFieldConfiguration -ApiToken $testApiToken -FieldKey 'AssetTag' -Description 'Device asset tag'
 
-        $Result.FieldKey | Should -Be 'AssetTag'
+        $Result.Key | Should -Be 'AssetTag'
 
         Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $Uri -eq '//unit.test/device-custom-fields' -and

--- a/Tests/Public/New-TeamViewerDeviceCustomFieldConfiguration.Tests.ps1
+++ b/Tests/Public/New-TeamViewerDeviceCustomFieldConfiguration.Tests.ps1
@@ -15,7 +15,7 @@ Describe 'New-TeamViewerDeviceCustomFieldConfiguration' {
 
         $Result = New-TeamViewerDeviceCustomFieldConfiguration -ApiToken $testApiToken -FieldKey 'AssetTag' -Description 'Device asset tag'
 
-        $Result.Key | Should -Be 'AssetTag'
+        $Result.Name | Should -Be 'AssetTag'
 
         Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $Uri -eq '//unit.test/device-custom-fields' -and

--- a/Tests/Public/New-TeamViewerRole.tests.ps1
+++ b/Tests/Public/New-TeamViewerRole.tests.ps1
@@ -53,7 +53,7 @@ Describe 'New-TeamViewerRole' {
         $Result | Should -Not -BeNullOrEmpty
         $Result | Should -BeOfType ([pscustomobject])
         $Result.PSObject.TypeNames | Should -Contain 'TeamViewerPS.Role'
-        $Result.RoleName | Should -Be $testRoleName
+        $Result.Name | Should -Be $testRoleName
 
         foreach ($Rule in $Result.Permissions) {
             $Result.Permissions.$Rule | Should -Be $testPermissions

--- a/Tests/Public/Remove-TeamViewerRole.Tests.ps1
+++ b/Tests/Public/Remove-TeamViewerRole.Tests.ps1
@@ -25,7 +25,7 @@ Describe 'Remove-TeamViewerRole' {
     It 'Should handle domain object as input' {
         $testRole = @{Id = $testRoleId; Name = 'test user role' } | ConvertTo-TeamViewerRole
 
-        Remove-TeamViewerRole -ApiToken $testApiToken -RoleId $testRole.RoleID
+        Remove-TeamViewerRole -ApiToken $testApiToken -RoleId $testRole.ID
 
         Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $ApiToken -eq $testApiToken -and $Uri -eq "//unit.test/userroles?userRoleId=$testRoleId" -and $Method -eq 'Delete'

--- a/Tests/Public/Set-TeamViewerDeviceCustomFieldConfiguration.Tests.ps1
+++ b/Tests/Public/Set-TeamViewerDeviceCustomFieldConfiguration.Tests.ps1
@@ -15,7 +15,7 @@ Describe 'Set-TeamViewerDeviceCustomFieldConfiguration' {
 
         $Result = Set-TeamViewerDeviceCustomFieldConfiguration -ApiToken $testApiToken -Id '00000000-0000-0000-0000-000000000001' -FieldKey 'AssetTag' -Description ''
 
-        $Result.Key | Should -Be 'AssetTag'
+        $Result.Name | Should -Be 'AssetTag'
 
         Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $Uri -eq '//unit.test/device-custom-fields/00000000-0000-0000-0000-000000000001' -and

--- a/Tests/Public/Set-TeamViewerDeviceCustomFieldConfiguration.Tests.ps1
+++ b/Tests/Public/Set-TeamViewerDeviceCustomFieldConfiguration.Tests.ps1
@@ -15,7 +15,7 @@ Describe 'Set-TeamViewerDeviceCustomFieldConfiguration' {
 
         $Result = Set-TeamViewerDeviceCustomFieldConfiguration -ApiToken $testApiToken -Id '00000000-0000-0000-0000-000000000001' -FieldKey 'AssetTag' -Description ''
 
-        $Result.FieldKey | Should -Be 'AssetTag'
+        $Result.Key | Should -Be 'AssetTag'
 
         Should -Invoke Invoke-TeamViewerRestMethod -Times 1 -Scope It -ParameterFilter {
             $Uri -eq '//unit.test/device-custom-fields/00000000-0000-0000-0000-000000000001' -and

--- a/Tests/Public/Set-TeamViewerGroup.Tests.ps1
+++ b/Tests/Public/Set-TeamViewerGroup.Tests.ps1
@@ -29,7 +29,7 @@ Describe 'Set-TeamViewerGroup' {
         $Body.name | Should -Be 'Unit Test Group'
     }
 
-    It 'Should include the optional policy ID in the request' {
+    It 'Should include the optional policy Id in the request' {
         Set-TeamViewerGroup -ApiToken $testApiToken -GroupId 'g1234' -Policy $testPolicyId
 
         $mockArgs.Body | Should -Not -BeNullOrEmpty


### PR DESCRIPTION
## Summary

Harmonize the output contracts of the private `ConvertTo-TeamViewer*` functions and update their consumers and tests.

- Normalize output property names and value types across converted TeamViewer objects.
- Remove obsolete custom `ToString()` members and update typed-object consumers and resolvers.
- Update private and public tests for the revised output contracts.
- Regenerate the bundled package and add a high-level changelog entry.

## Validation

- `Invoke-Pester -Path .`: 1,289 passed
- `Invoke-ScriptAnalyzer -Path . -Recurse -Settings .\Linters\PSScriptAnalyzer.psd1`: passed
- `Build\New-Package.ps1`: completed successfully